### PR TITLE
check for empty geometry

### DIFF
--- a/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/mapreduce/kde/GaussianCellMapper.java
+++ b/geowave-analytics/src/main/java/mil/nga/giat/geowave/analytics/mapreduce/kde/GaussianCellMapper.java
@@ -137,7 +137,7 @@ public class GaussianCellMapper extends
 				pt = ((Geometry) geomObj).getCentroid();
 			}
 		}
-		if (pt == null) {
+		if (pt == null || pt.isEmpty()) {
 			return;
 		}
 		for (int level = maxLevel; level >= minLevel; level--) {


### PR DESCRIPTION
.getCentroid() will return an empty point if the original geometry was empty - causes the whole map reduce job to die.
