### PR TITLE
Capture build info within artifacts

### DIFF
--- a/geowave-accumulo/src/main/resources/build.properties
+++ b/geowave-accumulo/src/main/resources/build.properties
@@ -1,0 +1,3 @@
+version=${project.parent.version}
+branch=${scmBranch}
+githash=${buildNumber}

--- a/geowave-deploy/pom.xml
+++ b/geowave-deploy/pom.xml
@@ -222,7 +222,37 @@
 				</dependencies>
 			</dependencyManagement>
 			<build>
+				<resources>
+					<resource>
+						<filtering>true</filtering>
+						<directory>${project.parent.relativePath}/geowave-store/src/main/resources</directory>
+						<includes>
+							<include>build.properties</include>
+						</includes>
+					</resource>
+				</resources>
 				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-resources-plugin</artifactId>
+						<version>2.7</version>
+						<configuration>
+							<encoding>UTF-8</encoding>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>buildnumber-maven-plugin</artifactId>
+						<version>1.3</version>
+						<executions>
+							<execution>
+								<phase>validate</phase>
+								<goals>
+									<goal>create</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-shade-plugin</artifactId>
@@ -324,7 +354,37 @@
 				</dependencies>
 			</dependencyManagement>
 			<build>
+				<resources>
+					<resource>
+						<filtering>true</filtering>
+						<directory>${project.parent.relativePath}/geowave-store/src/main/resources</directory>
+						<includes>
+							<include>build.properties</include>
+						</includes>
+					</resource>
+				</resources>
 				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-resources-plugin</artifactId>
+						<version>2.7</version>
+						<configuration>
+							<encoding>UTF-8</encoding>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>buildnumber-maven-plugin</artifactId>
+						<version>1.3</version>
+						<executions>
+							<execution>
+								<phase>validate</phase>
+								<goals>
+									<goal>create</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-shade-plugin</artifactId>

--- a/geowave-store/src/main/resources/build.properties
+++ b/geowave-store/src/main/resources/build.properties
@@ -1,0 +1,3 @@
+version=${project.parent.version}
+branch=${scmBranch}
+githash=${buildNumber}


### PR DESCRIPTION
Add build.properties file as a resource to both geowave artifacts and use the buildnumber and resources plugins to capture the values for each build. The values can then be inspected by downstream packaging processes to retrieve version info.
