### PR TITLE
tweaks to range comparison fine filtering

### DIFF
--- a/geowave-store/src/main/java/mil/nga/giat/geowave/store/data/PersistenceEncoding.java
+++ b/geowave-store/src/main/java/mil/nga/giat/geowave/store/data/PersistenceEncoding.java
@@ -1,23 +1,23 @@
 package mil.nga.giat.geowave.store.data;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.apache.commons.lang3.ArrayUtils;
-import org.apache.log4j.Logger;
-
 import mil.nga.giat.geowave.index.ByteArrayId;
 import mil.nga.giat.geowave.index.sfc.data.BasicNumericDataset;
 import mil.nga.giat.geowave.index.sfc.data.MultiDimensionalNumericData;
 import mil.nga.giat.geowave.index.sfc.data.NumericData;
-import mil.nga.giat.geowave.index.sfc.data.NumericRange;
 import mil.nga.giat.geowave.store.dimension.DimensionField;
 import mil.nga.giat.geowave.store.index.CommonIndexValue;
 import mil.nga.giat.geowave.store.index.Index;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.log4j.Logger;
+
+import com.google.common.math.DoubleMath;
 
 /**
  * This class models all of the necessary information for persisting data in
@@ -34,6 +34,7 @@ public class PersistenceEncoding
 	private final ByteArrayId dataId;
 	private final PersistentDataset<? extends CommonIndexValue> commonData;
 	private final static Logger LOGGER = Logger.getLogger(PersistenceEncoding.class);
+	private final static double DOUBLE_TOLERANCE = 1E-12d;
 
 	public PersistenceEncoding(
 			final ByteArrayId adapterId,
@@ -99,8 +100,8 @@ public class PersistenceEncoding
 		NumericData[] dataPerDimension;
 
 		DimensionRangePair(
-				DimensionField field,
-				NumericData data ) {
+				final DimensionField field,
+				final NumericData data ) {
 			dimensions = new DimensionField[] {
 				field
 			};
@@ -110,8 +111,8 @@ public class PersistenceEncoding
 		}
 
 		void add(
-				DimensionField field,
-				NumericData data ) {
+				final DimensionField field,
+				final NumericData data ) {
 			dimensions = ArrayUtils.add(
 					dimensions,
 					field);
@@ -121,8 +122,8 @@ public class PersistenceEncoding
 		}
 	}
 
-	
-	// Subclasses may want to override this behavior if the belief that the index strategy is optimal
+	// Subclasses may want to override this behavior if the belief that the
+	// index strategy is optimal
 	// to avoid the extra cost of checking the result
 	protected boolean overlaps(
 			final NumericData[] insertTileRange,
@@ -140,12 +141,12 @@ public class PersistenceEncoding
 		// However, provided in the correct order for interpretation, the
 		// CommonIndexValue can use those numeric data items
 		// to judge an overlap of range data.
-		Map<ByteArrayId, DimensionRangePair> fieldsRangeData = new HashMap<ByteArrayId, DimensionRangePair>(
+		final Map<ByteArrayId, DimensionRangePair> fieldsRangeData = new HashMap<ByteArrayId, DimensionRangePair>(
 				dimensions.length);
 
 		for (int d = 0; d < dimensions.length; d++) {
 			final ByteArrayId fieldId = dimensions[d].getFieldId();
-			DimensionRangePair fieldData = fieldsRangeData.get(fieldId);
+			final DimensionRangePair fieldData = fieldsRangeData.get(fieldId);
 			if (fieldData == null) {
 				fieldsRangeData.put(
 						fieldId,
@@ -161,8 +162,8 @@ public class PersistenceEncoding
 		}
 
 		boolean ok = true;
-		for (Entry<ByteArrayId, DimensionRangePair> entry : fieldsRangeData.entrySet()) {
-			ok &= commonData.getValue(
+		for (final Entry<ByteArrayId, DimensionRangePair> entry : fieldsRangeData.entrySet()) {
+			ok = ok && commonData.getValue(
 					entry.getKey()).overlaps(
 					entry.getValue().dimensions,
 					entry.getValue().dataPerDimension);
@@ -180,41 +181,34 @@ public class PersistenceEncoding
 	 */
 	public List<ByteArrayId> getInsertionIds(
 			final Index index ) {
-		MultiDimensionalNumericData boxRangeData = getNumericData(index.getIndexModel().getDimensions());
-		List<ByteArrayId> untrimmedResult = index.getIndexStrategy().getInsertionIds(
+		final MultiDimensionalNumericData boxRangeData = getNumericData(index.getIndexModel().getDimensions());
+		final List<ByteArrayId> untrimmedResult = index.getIndexStrategy().getInsertionIds(
 				boxRangeData);
 		final int size = untrimmedResult.size();
-		if (size > 2) {
-			Iterator<ByteArrayId> it = untrimmedResult.iterator();
+		if (size > 3) { // need at least 4 quadrants in a quadtree to create a
+			// concave shape where the mbr overlaps an area that the
+			// underlying polygon doesn't
+			final Iterator<ByteArrayId> it = untrimmedResult.iterator();
 			while (it.hasNext()) {
-				ByteArrayId insertionId = it.next();
-				MultiDimensionalNumericData md = correctForNormalizationError(index.getIndexStrategy().getRangeForId(
-						insertionId));
+				final ByteArrayId insertionId = it.next();
+				// final MultiDimensionalNumericData md =
+				// correctForNormalizationError(index.getIndexStrategy().getRangeForId(insertionId));
 				// used to check the result of the index strategy
 				if (LOGGER.isDebugEnabled() && checkCoverage(
 						boxRangeData,
-						md)) {
+						index.getIndexStrategy().getRangeForId(
+								insertionId))) {
 					LOGGER.error("Index strategy produced an unmatching tile during encoding and storing an entry");
 				}
 				if (!overlaps(
-						md.getDataPerDimension(),
-						index)) it.remove();
+						index.getIndexStrategy().getRangeForId(
+								insertionId).getDataPerDimension(),
+						index)) {
+					it.remove();
+				}
 			}
 		}
 		return untrimmedResult;
-	}
-
-	private MultiDimensionalNumericData correctForNormalizationError(
-			MultiDimensionalNumericData boxRangeData ) {
-		final NumericData[] currentDataSet = boxRangeData.getDataPerDimension();
-		final NumericData[] dataPerDimension = new NumericData[currentDataSet.length];
-		for (int d = 0; d < currentDataSet.length; d++) {
-			dataPerDimension[d] = new NumericRange(
-					currentDataSet[d].getMin() - 1E-12d,
-					currentDataSet[d].getMax() + 1E-12d);
-		}
-		return new BasicNumericDataset(
-				dataPerDimension);
 	}
 
 	/**
@@ -226,12 +220,21 @@ public class PersistenceEncoding
 	 * @return
 	 */
 	private boolean checkCoverage(
-			MultiDimensionalNumericData boxRangeData,
-			MultiDimensionalNumericData innerTile ) {
+			final MultiDimensionalNumericData boxRangeData,
+			final MultiDimensionalNumericData innerTile ) {
 		for (int i = 0; i < boxRangeData.getDimensionCount(); i++) {
-			double t0 = innerTile.getDataPerDimension()[i].getMax() - boxRangeData.getDataPerDimension()[i].getMin();
-			double t1 = boxRangeData.getDataPerDimension()[i].getMax() - innerTile.getDataPerDimension()[i].getMin();
-			if (Math.abs(t0 - t1) > (t0 + t1)) {
+			final double i1 = innerTile.getDataPerDimension()[i].getMin();
+			final double i2 = innerTile.getDataPerDimension()[i].getMax();
+			final double j1 = boxRangeData.getDataPerDimension()[i].getMin();
+			final double j2 = boxRangeData.getDataPerDimension()[i].getMax();
+			final boolean overlaps = ((i1 < j2) || DoubleMath.fuzzyEquals(
+					i1,
+					j2,
+					DOUBLE_TOLERANCE)) && ((i2 > j1) || DoubleMath.fuzzyEquals(
+					i2,
+					j1,
+					DOUBLE_TOLERANCE));
+			if (!overlaps) {
 				return false;
 			}
 		}

--- a/geowave-store/src/main/java/mil/nga/giat/geowave/store/dimension/GeometryWrapper.java
+++ b/geowave-store/src/main/java/mil/nga/giat/geowave/store/dimension/GeometryWrapper.java
@@ -4,6 +4,7 @@ import mil.nga.giat.geowave.index.sfc.data.NumericData;
 import mil.nga.giat.geowave.index.sfc.data.NumericRange;
 import mil.nga.giat.geowave.store.index.CommonIndexValue;
 
+import com.google.common.math.DoubleMath;
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Envelope;
 
@@ -17,6 +18,7 @@ public class GeometryWrapper implements
 {
 	private byte[] visibility;
 	private final com.vividsolutions.jts.geom.Geometry geometry;
+	private static final double DOUBLE_TOLERANCE = 1E-12d;
 
 	public GeometryWrapper(
 			final com.vividsolutions.jts.geom.Geometry geometry ) {
@@ -53,18 +55,17 @@ public class GeometryWrapper implements
 			final DimensionField[] fields,
 			final NumericData[] rangeData ) {
 
-		int latPosition = fields[0] instanceof LatitudeField ? 0 : 1;
-		int longPosition = fields[0] instanceof LatitudeField ? 1 : 0;
+		final int latPosition = fields[0] instanceof LatitudeField ? 0 : 1;
+		final int longPosition = fields[0] instanceof LatitudeField ? 1 : 0;
 		if (fields.length == 1) {
-			Envelope env = geometry.getEnvelopeInternal();
-			NumericRange r = latPosition == 0 ? new NumericRange(
+			final Envelope env = geometry.getEnvelopeInternal();
+			final NumericRange r = latPosition == 0 ? new NumericRange(
 					env.getMinY(),
 					env.getMaxY()) : new NumericRange(
 					env.getMinX(),
 					env.getMaxX());
-			double t0 = rangeData[0].getMax() - r.getMin();
-			double t1 = r.getMax() - rangeData[0].getMin();
-			return Math.abs(t0 - t1) <= (t0 + t1);
+			return ((rangeData[0].getMin() < r.getMax()) || DoubleMath.fuzzyEquals(rangeData[0].getMin(), r.getMax(), DOUBLE_TOLERANCE)) 
+					&& ((rangeData[0].getMax() > r.getMin()) || DoubleMath.fuzzyEquals(rangeData[0].getMax(), r.getMin(), DOUBLE_TOLERANCE));
 		}
 		return geometry.getFactory().createPolygon(
 				new Coordinate[] {
@@ -83,7 +84,7 @@ public class GeometryWrapper implements
 					new Coordinate(
 							rangeData[longPosition].getMin(),
 							rangeData[latPosition].getMin())
-				}).intersects(
+				}).buffer(DOUBLE_TOLERANCE).intersects(
 				geometry);
 	}
 }

--- a/geowave-store/src/test/java/mil/nga/giat/geowave/store/dimension/GeometryWrapperTest.java
+++ b/geowave-store/src/test/java/mil/nga/giat/geowave/store/dimension/GeometryWrapperTest.java
@@ -51,7 +51,7 @@ public class GeometryWrapperTest
 				}));
 		rangeData = new NumericRange(
 				33.7442334433,
-				33.75 - (1E-13d));
+				33.75 - (1E-10d));
 		assertFalse(wrapper.overlaps(
 				fields,
 				new NumericData[] {


### PR DESCRIPTION
Design question/intent before merging

In GeometryWrapper.java, in the case of having only 1 field we have a direct range comparison method.  The old version of this did _not_ use a fuzzy compare  (i.e. double + epsilon range).   

The new version does
- Is this what we want?  I would argue yes - if we use it anywhere, we should use it everywhere (deterministic behaviour).  Also, since this is a "rejection" type operation (i.e. we aren't generating a list, rather we are culling an already existing list) we don't have an danger of "wrong" data.  
- This required changing one of the tests to make pass (always a chancy thing) - the value a particular field was incremented by (1E-13) previously caused a failure when the match was exact, but now passed (since the tolerance was 1E-12.   The value was reduced to 1E-10 to cause it to fail again.   Hopefully I caught the intent of the test.
