### PR TITLE
Extract only the specified geometry attribute

### DIFF
--- a/extensions/adapters/vector/src/main/java/mil/nga/giat/geowave/adapter/vector/plugin/ExtractGeometryFilterVisitor.java
+++ b/extensions/adapters/vector/src/main/java/mil/nga/giat/geowave/adapter/vector/plugin/ExtractGeometryFilterVisitor.java
@@ -82,12 +82,12 @@ import com.vividsolutions.jts.geom.GeometryFactory;
 public class ExtractGeometryFilterVisitor extends
 		NullFilterVisitor
 {
-	public static final NullFilterVisitor GEOMETRY_VISITOR = new ExtractGeometryFilterVisitor(
-			GeoWaveGTDataStore.DEFAULT_CRS);
 
 	private static Logger LOGGER = LoggerFactory.getLogger(ExtractGeometryFilterVisitor.class);
 
 	private final CoordinateReferenceSystem crs;
+
+	private final String attributeOfInterest;
 
 	/**
 	 * This FilterVisitor is stateless - use
@@ -96,8 +96,10 @@ public class ExtractGeometryFilterVisitor extends
 	 * implementation.
 	 */
 	public ExtractGeometryFilterVisitor(
-			final CoordinateReferenceSystem crs ) {
+			final CoordinateReferenceSystem crs,
+			final String attributeOfInterest ) {
 		this.crs = crs;
+		this.attributeOfInterest = attributeOfInterest;
 	}
 
 	/**
@@ -108,11 +110,13 @@ public class ExtractGeometryFilterVisitor extends
 	 */
 	public static ExtractGeometryFilterVisitorResult getConstraints(
 			final Filter filter,
-			CoordinateReferenceSystem crs ) {
+			CoordinateReferenceSystem crs,
+			String attributeOfInterest ) {
 		final ExtractGeometryFilterVisitorResult geoAndCompareOpData = (ExtractGeometryFilterVisitorResult) filter
 				.accept(
 						new ExtractGeometryFilterVisitor(
-								crs),
+								crs,
+								attributeOfInterest),
 						null);
 		Geometry geo = geoAndCompareOpData.getGeometry();
 		// empty or infinite geometry simply return null as we can't create
@@ -202,14 +206,22 @@ public class ExtractGeometryFilterVisitor extends
 				filter.getMaxX(),
 				filter.getMinY(),
 				filter.getMaxY());
-		if (bbox != null) {
-			return bbox.union(new GeometryFactory().toGeometry(bounds));
+		if (this.attributeOfInterest.equals(filter.getExpression1().toString())) {
+			if (bbox != null) {
+				return bbox.union(new GeometryFactory().toGeometry(bounds));
+			}
+			else {
+				return new ExtractGeometryFilterVisitorResult(
+						bbox(bounds),
+						CompareOperation.INTERSECTS);
+			}
 		}
 		else {
 			return new ExtractGeometryFilterVisitorResult(
-					bbox(bounds),
-					CompareOperation.INTERSECTS);
+					infinity(),
+					null);
 		}
+
 	}
 
 	/**
@@ -360,12 +372,15 @@ public class ExtractGeometryFilterVisitor extends
 	public Object visit(
 			final Contains filter,
 			Object data ) {
-		data = filter.getExpression1().accept(
-				this,
-				data);
+		if (!this.attributeOfInterest.equals(filter.getExpression1().toString())) {
+			return new ExtractGeometryFilterVisitorResult(
+					infinity(),
+					null);
+		}
 		data = filter.getExpression2().accept(
 				this,
 				data);
+
 		// since predicate is defined relative to the query geometry we are
 		// using WITHIN
 		// which is converse of CONTAINS operator
@@ -380,9 +395,11 @@ public class ExtractGeometryFilterVisitor extends
 	public Object visit(
 			final Crosses filter,
 			Object data ) {
-		data = filter.getExpression1().accept(
-				this,
-				data);
+		if (!this.attributeOfInterest.equals(filter.getExpression1().toString())) {
+			return new ExtractGeometryFilterVisitorResult(
+					infinity(),
+					null);
+		}
 		data = filter.getExpression2().accept(
 				this,
 				data);
@@ -407,6 +424,11 @@ public class ExtractGeometryFilterVisitor extends
 			final DWithin filter,
 			final Object data ) {
 		final Geometry bbox = bbox(data);
+		if (!this.attributeOfInterest.equals(filter.getExpression1().toString())) {
+			return new ExtractGeometryFilterVisitorResult(
+					infinity(),
+					null);
+		}
 
 		// we have to take the reference geometry bbox and
 		// expand it by the distance.
@@ -464,9 +486,11 @@ public class ExtractGeometryFilterVisitor extends
 	public Object visit(
 			final Equals filter,
 			Object data ) {
-		data = filter.getExpression1().accept(
-				this,
-				data);
+		if (!this.attributeOfInterest.equals(filter.getExpression1().toString())) {
+			return new ExtractGeometryFilterVisitorResult(
+					infinity(),
+					null);
+		}
 		data = filter.getExpression2().accept(
 				this,
 				data);
@@ -479,9 +503,11 @@ public class ExtractGeometryFilterVisitor extends
 	public Object visit(
 			final Intersects filter,
 			Object data ) {
-		data = filter.getExpression1().accept(
-				this,
-				data);
+		if (!this.attributeOfInterest.equals(filter.getExpression1().toString())) {
+			return new ExtractGeometryFilterVisitorResult(
+					infinity(),
+					null);
+		}
 		data = filter.getExpression2().accept(
 				this,
 				data);
@@ -494,9 +520,11 @@ public class ExtractGeometryFilterVisitor extends
 	public Object visit(
 			final Overlaps filter,
 			Object data ) {
-		data = filter.getExpression1().accept(
-				this,
-				data);
+		if (!this.attributeOfInterest.equals(filter.getExpression1().toString())) {
+			return new ExtractGeometryFilterVisitorResult(
+					infinity(),
+					null);
+		}
 		data = filter.getExpression2().accept(
 				this,
 				data);
@@ -510,9 +538,11 @@ public class ExtractGeometryFilterVisitor extends
 	public Object visit(
 			final Touches filter,
 			Object data ) {
-		data = filter.getExpression1().accept(
-				this,
-				data);
+		if (!this.attributeOfInterest.equals(filter.getExpression1().toString())) {
+			return new ExtractGeometryFilterVisitorResult(
+					infinity(),
+					null);
+		}
 		data = filter.getExpression2().accept(
 				this,
 				data);
@@ -526,9 +556,11 @@ public class ExtractGeometryFilterVisitor extends
 	public Object visit(
 			final Within filter,
 			Object data ) {
-		data = filter.getExpression1().accept(
-				this,
-				data);
+		if (!this.attributeOfInterest.equals(filter.getExpression1().toString())) {
+			return new ExtractGeometryFilterVisitorResult(
+					infinity(),
+					null);
+		}
 		data = filter.getExpression2().accept(
 				this,
 				data);

--- a/extensions/adapters/vector/src/main/java/mil/nga/giat/geowave/adapter/vector/plugin/GeoWaveFeatureCollection.java
+++ b/extensions/adapters/vector/src/main/java/mil/nga/giat/geowave/adapter/vector/plugin/GeoWaveFeatureCollection.java
@@ -348,10 +348,16 @@ public class GeoWaveFeatureCollection extends
 		if (envelope != null) {
 			return new GeometryFactory().toGeometry(envelope);
 		}
-
+		String geomAtrributeName = reader
+				.getComponents()
+				.getAdapter()
+				.getFeatureType()
+				.getGeometryDescriptor()
+				.getLocalName();
 		ExtractGeometryFilterVisitorResult geoAndCompareOp = ExtractGeometryFilterVisitor.getConstraints(
 				query.getFilter(),
-				GeoWaveGTDataStore.DEFAULT_CRS);
+				GeoWaveGTDataStore.DEFAULT_CRS,
+				geomAtrributeName);
 		if (geoAndCompareOp == null) {
 			return reader.clipIndexedBBOXConstraints(null);
 		}

--- a/extensions/adapters/vector/src/main/java/mil/nga/giat/geowave/adapter/vector/query/cql/CQLQuery.java
+++ b/extensions/adapters/vector/src/main/java/mil/nga/giat/geowave/adapter/vector/query/cql/CQLQuery.java
@@ -176,7 +176,8 @@ public class CQLQuery implements
 			final ExtractGeometryFilterVisitorResult geometryAndCompareOp = ExtractGeometryFilterVisitor
 					.getConstraints(
 							cqlFilter,
-							adapter.getFeatureType().getCoordinateReferenceSystem());
+							adapter.getFeatureType().getCoordinateReferenceSystem(),
+							adapter.getFeatureType().getGeometryDescriptor().getLocalName());
 			final TemporalConstraintsSet timeConstraintSet = new ExtractTimeFilterVisitor(
 					adapter.getTimeDescriptors()).getConstraints(cqlFilter);
 

--- a/extensions/adapters/vector/src/test/java/mil/nga/giat/geowave/adapter/vector/plugin/ExtractGeometryFilterVisitorTest.java
+++ b/extensions/adapters/vector/src/test/java/mil/nga/giat/geowave/adapter/vector/plugin/ExtractGeometryFilterVisitorTest.java
@@ -33,7 +33,10 @@ import mil.nga.giat.geowave.core.geotime.store.filter.SpatialQueryFilter.Compare
 
 public class ExtractGeometryFilterVisitorTest
 {
-	final ExtractGeometryFilterVisitor visitorWithDescriptor = (ExtractGeometryFilterVisitor) ExtractGeometryFilterVisitor.GEOMETRY_VISITOR;
+	final String geomAttributeName = "geom";
+	final ExtractGeometryFilterVisitor visitorWithDescriptor = new ExtractGeometryFilterVisitor(
+			GeoWaveGTDataStore.DEFAULT_CRS,
+			geomAttributeName);
 
 	@Test
 	public void testDWithin()
@@ -41,7 +44,9 @@ public class ExtractGeometryFilterVisitorTest
 			TransformException,
 			ParseException {
 
-		Filter filter = CQL.toFilter("DWITHIN(geom, POINT(-122.7668 0.4979), 233.7, meters)");
+		Filter filter = CQL.toFilter(String.format(
+				"DWITHIN(%s, POINT(-122.7668 0.4979), 233.7, meters)",
+				geomAttributeName));
 		Query query = new Query(
 				"type",
 				filter);
@@ -73,7 +78,9 @@ public class ExtractGeometryFilterVisitorTest
 			TransformException,
 			ParseException {
 
-		Filter filter = CQL.toFilter("DWITHIN(geom, POINT(179.9998 0.79), 13.7, kilometers)");
+		Filter filter = CQL.toFilter(String.format(
+				"DWITHIN(%s, POINT(179.9998 0.79), 13.7, kilometers)",
+				geomAttributeName));
 		Query query = new Query(
 				"type",
 				filter);
@@ -105,7 +112,9 @@ public class ExtractGeometryFilterVisitorTest
 			TransformException,
 			ParseException {
 
-		Filter filter = CQL.toFilter("BBOX(geom, 0, 0, 10, 25)");
+		Filter filter = CQL.toFilter(String.format(
+				"BBOX(%s, 0, 0, 10, 25)",
+				geomAttributeName));
 		Query query = new Query(
 				"type",
 				filter);
@@ -133,7 +142,9 @@ public class ExtractGeometryFilterVisitorTest
 			TransformException,
 			ParseException {
 
-		Filter filter = CQL.toFilter("INTERSECTS(geom, POLYGON((0 0, 0 25, 10 25, 10 0, 0 0)))");
+		Filter filter = CQL.toFilter(String.format(
+				"INTERSECTS(%s, POLYGON((0 0, 0 25, 10 25, 10 0, 0 0)))",
+				geomAttributeName));
 		Query query = new Query(
 				"type",
 				filter);
@@ -161,7 +172,9 @@ public class ExtractGeometryFilterVisitorTest
 			TransformException,
 			ParseException {
 
-		Filter filter = CQL.toFilter("OVERLAPS(geom, POLYGON((0 0, 0 25, 10 25, 10 0, 0 0)))");
+		Filter filter = CQL.toFilter(String.format(
+				"OVERLAPS(%s, POLYGON((0 0, 0 25, 10 25, 10 0, 0 0)))",
+				geomAttributeName));
 		Query query = new Query(
 				"type",
 				filter);
@@ -189,7 +202,9 @@ public class ExtractGeometryFilterVisitorTest
 			TransformException,
 			ParseException {
 
-		Filter filter = CQL.toFilter("EQUALS(geom, POLYGON((0 0, 0 25, 10 25, 10 0, 0 0)))");
+		Filter filter = CQL.toFilter(String.format(
+				"EQUALS(geom, POLYGON((0 0, 0 25, 10 25, 10 0, 0 0)))",
+				geomAttributeName));
 		Query query = new Query(
 				"type",
 				filter);
@@ -217,7 +232,9 @@ public class ExtractGeometryFilterVisitorTest
 			TransformException,
 			ParseException {
 
-		Filter filter = CQL.toFilter("CROSSES(geom, POLYGON((0 0, 0 25, 10 25, 10 0, 0 0)))");
+		Filter filter = CQL.toFilter(String.format(
+				"CROSSES(%s, POLYGON((0 0, 0 25, 10 25, 10 0, 0 0)))",
+				geomAttributeName));
 		Query query = new Query(
 				"type",
 				filter);
@@ -245,7 +262,9 @@ public class ExtractGeometryFilterVisitorTest
 			TransformException,
 			ParseException {
 
-		Filter filter = CQL.toFilter("TOUCHES(geom, POLYGON((0 0, 0 25, 10 25, 10 0, 0 0)))");
+		Filter filter = CQL.toFilter(String.format(
+				"TOUCHES(%s, POLYGON((0 0, 0 25, 10 25, 10 0, 0 0)))",
+				geomAttributeName));
 		Query query = new Query(
 				"type",
 				filter);
@@ -273,7 +292,9 @@ public class ExtractGeometryFilterVisitorTest
 			TransformException,
 			ParseException {
 
-		Filter filter = CQL.toFilter("WITHIN(geom, POLYGON((0 0, 0 25, 10 25, 10 0, 0 0)))");
+		Filter filter = CQL.toFilter(String.format(
+				"WITHIN(%s, POLYGON((0 0, 0 25, 10 25, 10 0, 0 0)))",
+				geomAttributeName));
 		Query query = new Query(
 				"type",
 				filter);
@@ -301,7 +322,9 @@ public class ExtractGeometryFilterVisitorTest
 			TransformException,
 			ParseException {
 
-		Filter filter = CQL.toFilter("CONTAINS(geom, POLYGON((0 0, 0 25, 10 25, 10 0, 0 0)))");
+		Filter filter = CQL.toFilter(String.format(
+				"CONTAINS(geom, POLYGON((0 0, 0 25, 10 25, 10 0, 0 0)))",
+				geomAttributeName));
 		Query query = new Query(
 				"type",
 				filter);
@@ -329,7 +352,9 @@ public class ExtractGeometryFilterVisitorTest
 			TransformException,
 			ParseException {
 
-		Filter filter = CQL.toFilter("DISJOINT(geom, POLYGON((0 0, 0 25, 10 25, 10 0, 0 0)))");
+		Filter filter = CQL.toFilter(String.format(
+				"DISJOINT(%s, POLYGON((0 0, 0 25, 10 25, 10 0, 0 0)))",
+				geomAttributeName));
 		Query query = new Query(
 				"type",
 				filter);
@@ -355,8 +380,10 @@ public class ExtractGeometryFilterVisitorTest
 		// we are testing to see if we are able to combine simple geometric
 		// relations with similar predicates
 		// into a single query geometry/predicate
-		Filter filter = CQL
-				.toFilter("INTERSECTS(geom, POLYGON((0 0, 0 50, 20 50, 20 0, 0 0))) AND BBOX(geom, 0, 0, 10, 25)");
+		Filter filter = CQL.toFilter(String.format(
+				"INTERSECTS(%s, POLYGON((0 0, 0 50, 20 50, 20 0, 0 0))) AND BBOX(%s, 0, 0, 10, 25)",
+				geomAttributeName,
+				geomAttributeName));
 		Query query = new Query(
 				"type",
 				filter);
@@ -392,7 +419,11 @@ public class ExtractGeometryFilterVisitorTest
 		// we can combine geometries for the purpose of deriving linear
 		// constraints
 		Filter filter = CQL
-				.toFilter("INTERSECTS(geom, POLYGON((0 0, 0 50, 20 50, 20 0, 0 0))) AND CROSSES(geom, POLYGON((0 0, 0 25, 10 25, 10 0, 0 0)))");
+				.toFilter(String
+						.format(
+								"INTERSECTS(%s, POLYGON((0 0, 0 50, 20 50, 20 0, 0 0))) AND CROSSES(%s, POLYGON((0 0, 0 25, 10 25, 10 0, 0 0)))",
+								geomAttributeName,
+								geomAttributeName));
 		Query query = new Query(
 				"type",
 				filter);
@@ -428,7 +459,11 @@ public class ExtractGeometryFilterVisitorTest
 		// we can combine geometries for the purpose of deriving linear
 		// constraints
 		Filter filter = CQL
-				.toFilter("OVERLAPS(geom, POLYGON((0 0, 0 50, 20 50, 20 0, 0 0))) OR TOUCHES(geom, POLYGON((0 0, 0 25, 10 25, 10 0, 0 0)))");
+				.toFilter(String
+						.format(
+								"OVERLAPS(%s, POLYGON((0 0, 0 50, 20 50, 20 0, 0 0))) OR TOUCHES(%s, POLYGON((0 0, 0 25, 10 25, 10 0, 0 0)))",
+								geomAttributeName,
+								geomAttributeName));
 		Query query = new Query(
 				"type",
 				filter);
@@ -461,7 +496,46 @@ public class ExtractGeometryFilterVisitorTest
 		// to extract query geometry. Note, that returned predicate is null
 		// since we can't represent
 		// CQL expression fully into single query geometry and predicate
-		Filter filter = CQL.toFilter("CROSSES(geom, POLYGON((0 0, 0 25, 10 25, 10 0, 0 0))) AND location == 'abc'");
+		Filter filter = CQL.toFilter(String.format(
+				"CROSSES(%s, POLYGON((0 0, 0 25, 10 25, 10 0, 0 0))) AND location == 'abc'",
+				geomAttributeName));
+		Query query = new Query(
+				"type",
+				filter);
+
+		final ExtractGeometryFilterVisitorResult result = (ExtractGeometryFilterVisitorResult) query
+				.getFilter()
+				.accept(
+						visitorWithDescriptor,
+						null);
+
+		final Envelope bounds = new Envelope(
+				0,
+				10,
+				0,
+				25);
+		final Geometry bbox = new GeometryFactory().toGeometry(bounds);
+
+		assertTrue(bbox.equalsTopo(result.getGeometry()));
+		assertTrue(result.getCompareOp() == null);
+	}
+
+	@Test
+	public void testWithMultipleAttributes()
+			throws CQLException,
+			TransformException,
+			ParseException {
+
+		// In this test query, we have constrains over multiple geometric
+		// attributes.
+		// The ExtractGeometryFilterVisitor class should only extracts
+		// geometric constrains associated with the specified attribute name and
+		// ignore others.
+		Filter filter = CQL
+				.toFilter(String
+						.format(
+								"INTERSECTS(%s, POLYGON((0 0, 0 25, 10 25, 10 0, 0 0))) AND INTERSECTS(geomOtherAttr, POLYGON((0 0, 0 5, 5 5, 5 0, 0 0)))",
+								geomAttributeName));
 		Query query = new Query(
 				"type",
 				filter);

--- a/extensions/cli/landsat8/src/main/java/mil/nga/giat/geowave/format/landsat8/RasterIngestRunner.java
+++ b/extensions/cli/landsat8/src/main/java/mil/nga/giat/geowave/format/landsat8/RasterIngestRunner.java
@@ -227,7 +227,8 @@ public class RasterIngestRunner extends
 				final ExtractGeometryFilterVisitorResult geometryAndCompareOp = ExtractGeometryFilterVisitor
 						.getConstraints(
 								filter,
-								GeoWaveGTRasterFormat.DEFAULT_CRS);
+								GeoWaveGTRasterFormat.DEFAULT_CRS,
+								SceneFeatureIterator.SHAPE_ATTRIBUTE_NAME);
 				Geometry geometry = geometryAndCompareOp.getGeometry();
 				if (geometry != null) {
 					// go ahead and intersect this with the scene geometry


### PR DESCRIPTION
Fixed an issue to extract out correct geometry constraints and predicate when you have multiple geometric attributes inside a CQL expression