### PR TITLE
Add GDELT download & ingest to Zeppelin example

### DIFF
--- a/examples/data/notebooks/zeppelin/GDELT-Quick-Start.json
+++ b/examples/data/notebooks/zeppelin/GDELT-Quick-Start.json
@@ -1,1 +1,464 @@
-﻿{"paragraphs":[{"text":"%md\n## Welcome to the GeoWave KMeans GDELT Example (EMR Version).\n##### This is a live note - you can run the code yourself.\n\n### Setup\n<p>\nThe only prerequisite to running this example is increasing your shell interpreter's timeout.<br>\nGo to the <b>Interpreter</b> page, and scroll down to the <b>'sh'</b> section. Click on the <b>'edit'</b> button.<br><br>\nSet the <b>'shell.command.timeout.millisecs'</b> entry to <b>600000</b> (10 minutes).\n</p>\n\n### Execution\n<p>\nThe list of paragraphs below needs to be run sequentially.<br>\nStart at the top, and click the <b>play</b> button in each paragraph, waiting for completion.<br>\nEach paragraph is labeled and commented so you can tell what's happening. A paragraph will be marked<br>\nwith a <b>FINISHED</b> indicator next to the play button when it has run without error.<br><br>\nEnjoy!\n</p>","user":"anonymous","dateUpdated":"2017-08-21T19:56:49+0000","config":{"tableHide":false,"editorSetting":{"language":"markdown","editOnDblClick":true},"colWidth":12,"editorMode":"ace/mode/markdown","editorHide":true,"results":{},"enabled":true},"settings":{"params":{},"forms":{}},"results":{"code":"SUCCESS","msg":[{"type":"HTML","data":"<h2>Welcome to the GeoWave KMeans GDELT Example (EMR Version).</h2>\n<h5>This is a live note - you can run the code yourself.</h5>\n<h3>Setup</h3>\n<p>\nThe only prerequisite to running this example is increasing your shell interpreter's timeout.<br>\nGo to the <b>Interpreter</b> page, and scroll down to the <b>'sh'</b> section. Click on the <b>'edit'</b> button.<br><br>\nSet the <b>'shell.command.timeout.millisecs'</b> entry to <b>600000</b> (10 minutes).\n</p>\n<h3>Execution</h3>\n<p>\nThe list of paragraphs below needs to be run sequentially.<br>\nStart at the top, and click the <b>play</b> button in each paragraph, waiting for completion.<br>\nEach paragraph is labeled and commented so you can tell what's happening. A paragraph will be marked<br>\nwith a <b>FINISHED</b> indicator next to the play button when it has run without error.<br><br>\nEnjoy!\n</p>\n"}]},"apps":[],"jobName":"paragraph_1503345355428_482387398","id":"20170814-190601_1767735731","dateCreated":"2017-08-21T19:55:55+0000","dateStarted":"2017-08-21T19:56:49+0000","dateFinished":"2017-08-21T19:56:50+0000","status":"FINISHED","progressUpdateIntervalMs":500,"focus":true,"$$hashKey":"object:4119"},{"title":"Configure GeoWave","text":"%sh\n# clear out potential old runs\ngeowave config rmstore kmeans\ngeowave config rmstore gdelt\n\n# configure geowave connection params for name stores \"germany_gpx_accumulo\" and \"kmeans_hbase\"\ngeowave config addstore gdelt --gwNamespace geowave.gdelt -t hbase --zookeeper $HOSTNAME:2181\ngeowave config addstore kmeans --gwNamespace geowave.kmeans -t hbase --zookeeper $HOSTNAME:2181\n\n# set up geoserver\ngeowave config geoserver \"$HOSTNAME:8000\"\n\n# add gdelt layer\ngeowave gs addlayer gdelt -id gdeltevent\ncd /mnt/tmp\nwget s3.amazonaws.com/geowave/latest/scripts/emr/quickstart/SubsamplePoints.sld\ngeowave gs addstyle SubsamplePoints -sld /mnt/tmp/SubsamplePoints.sld\ngeowave gs setls gdeltevent --styleName SubsamplePoints\n","user":"anonymous","dateUpdated":"2017-08-21T21:32:55+0000","config":{"tableHide":false,"editorSetting":{"language":"sh","editOnDblClick":false},"colWidth":12,"editorMode":"ace/mode/sh","editorHide":false,"title":true,"results":{},"enabled":true},"settings":{"params":{},"forms":{}},"results":{"code":"SUCCESS","msg":[{"type":"TEXT","data":"21 Aug 20:08:58 DEBUG [util.Shell] - setsid exited with exit code 0\n21 Aug 20:08:58 DEBUG [security.Groups] -  Creating new Groups object\n21 Aug 20:08:58 DEBUG [util.NativeCodeLoader] - Trying to load the custom-built native-hadoop library...\n21 Aug 20:08:58 DEBUG [util.NativeCodeLoader] - Failed to load native-hadoop with error: java.lang.UnsatisfiedLinkError: no hadoop in java.library.path\n21 Aug 20:08:58 DEBUG [util.NativeCodeLoader] - java.library.path=/usr/java/packages/lib/amd64:/usr/lib64:/lib64:/lib:/usr/lib\n21 Aug 20:08:58 WARN [util.NativeCodeLoader] - Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n21 Aug 20:08:58 DEBUG [util.PerformanceAdvisory] - Falling back to shell based\n21 Aug 20:08:58 DEBUG [security.JniBasedUnixGroupsMappingWithFallback] - Group mapping impl=org.apache.hadoop.security.ShellBasedUnixGroupsMapping\n21 Aug 20:08:58 DEBUG [security.Groups] - Group mapping impl=org.apache.hadoop.security.JniBasedUnixGroupsMappingWithFallback; cacheTimeout=300000; warningDeltaMs=5000\n21 Aug 20:08:58 DEBUG [lib.MutableMetricsFactory] - field org.apache.hadoop.metrics2.lib.MutableRate org.apache.hadoop.security.UserGroupInformation$UgiMetrics.loginSuccess with annotation @org.apache.hadoop.metrics2.annotation.Metric(about=, sampleName=Ops, always=false, type=DEFAULT, valueName=Time, value=[Rate of successful kerberos logins and latency (milliseconds)])\n21 Aug 20:08:58 DEBUG [lib.MutableMetricsFactory] - field org.apache.hadoop.metrics2.lib.MutableRate org.apache.hadoop.security.UserGroupInformation$UgiMetrics.loginFailure with annotation @org.apache.hadoop.metrics2.annotation.Metric(about=, sampleName=Ops, always=false, type=DEFAULT, valueName=Time, value=[Rate of failed kerberos logins and latency (milliseconds)])\n21 Aug 20:08:58 DEBUG [lib.MutableMetricsFactory] - field org.apache.hadoop.metrics2.lib.MutableRate org.apache.hadoop.security.UserGroupInformation$UgiMetrics.getGroups with annotation @org.apache.hadoop.metrics2.annotation.Metric(about=, sampleName=Ops, always=false, type=DEFAULT, valueName=Time, value=[GetGroups])\n21 Aug 20:08:58 DEBUG [impl.MetricsSystemImpl] - UgiMetrics, User and group related metrics\n21 Aug 20:08:58 DEBUG [util.KerberosName] - Kerberos krb5 configuration not found, setting default realm to empty\n21 Aug 20:08:58 DEBUG [security.UserGroupInformation] - hadoop login\n21 Aug 20:08:58 DEBUG [security.UserGroupInformation] - hadoop login commit\n21 Aug 20:08:58 DEBUG [security.UserGroupInformation] - using local user:UnixPrincipal: zeppelin\n21 Aug 20:08:58 DEBUG [security.UserGroupInformation] - Using user: \"UnixPrincipal: zeppelin\" with name zeppelin\n21 Aug 20:08:58 DEBUG [security.UserGroupInformation] - User entry: \"zeppelin\"\n21 Aug 20:08:58 DEBUG [security.UserGroupInformation] - UGI loginUser:zeppelin (auth:SIMPLE)\n21 Aug 20:08:59 INFO [zookeeper.RecoverableZooKeeper] - Process identifier=hconnection-0x2df3b89c connecting to ZooKeeper ensemble=ip-10-0-0-73:2181\n21 Aug 20:08:59 INFO [zookeeper.ZooKeeper] - Client environment:zookeeper.version=3.4.6-1569965, built on 02/20/2014 09:09 GMT\n21 Aug 20:08:59 INFO [zookeeper.ZooKeeper] - Client environment:host.name=ip-10-0-0-73.ec2.internal\n21 Aug 20:08:59 INFO [zookeeper.ZooKeeper] - Client environment:java.version=1.8.0_141\n21 Aug 20:08:59 INFO [zookeeper.ZooKeeper] - Client environment:java.vendor=Oracle Corporation\n21 Aug 20:08:59 INFO [zookeeper.ZooKeeper] - Client environment:java.home=/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.141-1.b16.32.amzn1.x86_64/jre\n21 Aug 20:08:59 INFO [zookeeper.ZooKeeper] - Client environment:java.class.path=/usr/local/geowave-0.9.6-apache/tools/geowave-tools-0.9.6-apache.jar:/usr/local/geowave-0.9.6-apache/tools/plugins/*\n21 Aug 20:08:59 INFO [zookeeper.ZooKeeper] - Client environment:java.library.path=/usr/java/packages/lib/amd64:/usr/lib64:/lib64:/lib:/usr/lib\n21 Aug 20:08:59 INFO [zookeeper.ZooKeeper] - Client environment:java.io.tmpdir=/tmp\n21 Aug 20:08:59 INFO [zookeeper.ZooKeeper] - Client environment:java.compiler=<NA>\n21 Aug 20:08:59 INFO [zookeeper.ZooKeeper] - Client environment:os.name=Linux\n21 Aug 20:08:59 INFO [zookeeper.ZooKeeper] - Client environment:os.arch=amd64\n21 Aug 20:08:59 INFO [zookeeper.ZooKeeper] - Client environment:os.version=4.4.35-33.55.amzn1.x86_64\n21 Aug 20:08:59 INFO [zookeeper.ZooKeeper] - Client environment:user.name=zeppelin\n21 Aug 20:08:59 INFO [zookeeper.ZooKeeper] - Client environment:user.home=/var/lib/zeppelin\n21 Aug 20:08:59 INFO [zookeeper.ZooKeeper] - Client environment:user.dir=/mnt/var/lib/zeppelin\n21 Aug 20:08:59 INFO [zookeeper.ZooKeeper] - Initiating client connection, connectString=ip-10-0-0-73:2181 sessionTimeout=90000 watcher=org.apache.hadoop.hbase.zookeeper.PendingWatcher@77f80c04\n21 Aug 20:08:59 DEBUG [zookeeper.ClientCnxn] - zookeeper.disableAutoWatchReset is false\n21 Aug 20:08:59 INFO [zookeeper.ClientCnxn] - Opening socket connection to server ip-10-0-0-73.ec2.internal/10.0.0.73:2181. Will not attempt to authenticate using SASL (unknown error)\n21 Aug 20:08:59 INFO [zookeeper.ClientCnxn] - Socket connection established to ip-10-0-0-73.ec2.internal/10.0.0.73:2181, initiating session\n21 Aug 20:08:59 DEBUG [zookeeper.ClientCnxn] - Session establishment request sent on ip-10-0-0-73.ec2.internal/10.0.0.73:2181\n21 Aug 20:08:59 INFO [zookeeper.ClientCnxn] - Session establishment complete on server ip-10-0-0-73.ec2.internal/10.0.0.73:2181, sessionid = 0x15e064530cc0014, negotiated timeout = 40000\n21 Aug 20:08:59 DEBUG [zookeeper.ZooKeeperWatcher] - hconnection-0x2df3b89c0x0, quorum=ip-10-0-0-73:2181, baseZNode=/hbase Received ZooKeeper Event, type=None, state=SyncConnected, path=null\n21 Aug 20:08:59 DEBUG [zookeeper.ZooKeeperWatcher] - hconnection-0x2df3b89c-0x15e064530cc0014 connected\n21 Aug 20:08:59 DEBUG [zookeeper.ClientCnxn] - Reading reply sessionid:0x15e064530cc0014, packet:: clientPath:null serverPath:null finished:false header:: 1,3  replyHeader:: 1,270,0  request:: '/hbase/hbaseid,F  response:: s{34,34,1503343780060,1503343780060,0,0,0,0,67,0,34} \n21 Aug 20:08:59 DEBUG [zookeeper.ClientCnxn] - Reading reply sessionid:0x15e064530cc0014, packet:: clientPath:null serverPath:null finished:false header:: 2,4  replyHeader:: 2,270,0  request:: '/hbase/hbaseid,F  response:: #ffffffff000146d61737465723a3136303030fffffffb36ffffff9e3dffffffe963ffffffe5fffffff550425546a2463653132386434362d343132342d343936352d626337662d663062383138666461626334,s{34,34,1503343780060,1503343780060,0,0,0,0,67,0,34} \n21 Aug 20:08:59 DEBUG [ipc.AbstractRpcClient] - Codec=org.apache.hadoop.hbase.codec.KeyValueCodec@72ef8d15, compressor=null, tcpKeepAlive=true, tcpNoDelay=true, connectTO=10000, readTO=20000, writeTO=60000, minIdleTimeBeforeClose=120000, maxRetries=0, fallbackAllowed=false, bind address=null\n21 Aug 20:08:59 DEBUG [geoserver.GeoServerRestClient] - Adapter list for gdelt with adapterId = gdeltevent: \n21 Aug 20:08:59 DEBUG [zookeeper.ClientCnxn] - Reading reply sessionid:0x15e064530cc0014, packet:: clientPath:null serverPath:null finished:false header:: 3,4  replyHeader:: 3,270,0  request:: '/hbase/meta-region-server,F  response:: #ffffffff0001a726567696f6e7365727665723a313630323071ffffffec3effffffa0fffffff25affffffc95b50425546a25a1969702d31302d302d302d39392e6563322e696e7465726e616c10ffffff947d18ffffff92ffffff88ffffff95ffffffb2ffffffe02b100183,s{87,87,1503343786729,1503343786729,0,0,0,0,78,0,87} \n21 Aug 20:08:59 DEBUG [zookeeper.ClientCnxn] - Reading reply sessionid:0x15e064530cc0014, packet:: clientPath:null serverPath:null finished:false header:: 4,8  replyHeader:: 4,270,0  request:: '/hbase,F  response:: v{'replication,'meta-region-server,'rs,'splitWAL,'backup-masters,'table-lock,'flush-table-proc,'region-in-transition,'online-snapshot,'master,'switch,'running,'recovering-regions,'draining,'namespace,'hbaseid,'table} \n21 Aug 20:08:59 DEBUG [ipc.RpcClientImpl] - Use SIMPLE authentication for service ClientService, sasl=false\n21 Aug 20:08:59 DEBUG [ipc.RpcClientImpl] - Connecting to ip-10-0-0-99.ec2.internal/10.0.0.99:16020\n21 Aug 20:08:59 DEBUG [ipc.RpcClientImpl] - Use SIMPLE authentication for service ClientService, sasl=false\n21 Aug 20:08:59 DEBUG [ipc.RpcClientImpl] - Connecting to ip-10-0-0-229.ec2.internal/10.0.0.229:16020\nAug 21, 2017 8:09:00 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'GeoServerResourceLoader', but ApplicationContext is unset.\nAug 21, 2017 8:09:00 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'GeoServerResourceLoader', but ApplicationContext is unset.\nAug 21, 2017 8:09:00 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'ExtensionFilter', but ApplicationContext is unset.\nAug 21, 2017 8:09:00 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'ExtensionProvider', but ApplicationContext is unset.\nAug 21, 2017 8:09:00 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'ExtensionFilter', but ApplicationContext is unset.\nAug 21, 2017 8:09:00 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'GeoServerResourceLoader', but ApplicationContext is unset.\nAug 21, 2017 8:09:00 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'GeoServerResourceLoader', but ApplicationContext is unset.\nAug 21, 2017 8:09:00 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'ExtensionFilter', but ApplicationContext is unset.\nAug 21, 2017 8:09:00 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'ExtensionProvider', but ApplicationContext is unset.\nAug 21, 2017 8:09:00 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'ExtensionFilter', but ApplicationContext is unset.\n21 Aug 20:09:00 ERROR [persist.PersistableFactory] - '600' already registered for class 'mil.nga.giat.geowave.adapter.raster.Resolution'.  Cannot register 'class mil.nga.giat.geowave.format.twitter.TwitterIngestPlugin' with id '600'\n21 Aug 20:09:00 ERROR [persist.PersistableFactory] - '601' already registered for class 'mil.nga.giat.geowave.adapter.raster.adapter.CompoundHierarchicalIndexStrategyWrapper'.  Cannot register 'class mil.nga.giat.geowave.format.twitter.TwitterIngestPlugin$IngestTwitterFromHdfs' with id '601'\n21 Aug 20:09:00 INFO [util.FeatureDataUtils] - Generating patched classloader\n21 Aug 20:09:00 DEBUG [geoserver.GeoServerRestClient] - getAdapterInfo for id = gdeltevent\n21 Aug 20:09:00 DEBUG [geoserver.GeoServerRestClient] - > Adapter ID: gdeltevent\n21 Aug 20:09:00 DEBUG [geoserver.GeoServerRestClient] - > Adapter Type: FeatureDataAdapter\n21 Aug 20:09:00 DEBUG [geoserver.GeoServerRestClient] - id matches adapter id\n21 Aug 20:09:00 DEBUG [geoserver.GeoServerRestClient] - > 'gdeltevent' adapter passed filter\n21 Aug 20:09:00 DEBUG [geoserver.GeoServerRestClient] - getStoreAdapterInfo(gdelt) got 1 ids\n21 Aug 20:09:00 DEBUG [geoserver.GeoServerRestClient] - Finished retrieving adapter list\n21 Aug 20:09:03 DEBUG [geoserver.GeoServerRestClient] - Checking for existing feature layer: gdeltevent\n21 Aug 20:09:03 DEBUG [geoserver.GeoServerRestClient] - Get feature layer: gdeltevent returned 404\nAdd GeoServer layer for 'gdelt: OK\n{\n  \"description\": \"Successfully added:\",\n  \"layers\": [  {\n    \"id\": \"gdeltevent\",\n    \"type\": \"vector\"\n  }]\n}\n--2017-08-21 20:09:04--  http://s3.amazonaws.com/geowave/latest/scripts/emr/quickstart/SubsamplePoints.sld\nResolving s3.amazonaws.com (s3.amazonaws.com)... 52.216.225.115\nConnecting to s3.amazonaws.com (s3.amazonaws.com)|52.216.225.115|:80... connected.\nHTTP request sent, awaiting response... 200 OK\nLength: 2237 (2.2K) [binary/octet-stream]\nSaving to: ‘SubsamplePoints.sld’\n\n     0K ..                                                    100%  173M=0s\n\n2017-08-21 20:09:04 (173 MB/s) - ‘SubsamplePoints.sld’ saved [2237/2237]\n\nAdd style for 'SubsamplePoints' on GeoServer: OK\nSet style for GeoServer layer 'gdeltevent: OK\n\n"}]},"apps":[],"jobName":"paragraph_1503345355434_481617900","id":"20170809-181755_1512238840","dateCreated":"2017-08-21T19:55:55+0000","dateStarted":"2017-08-21T20:08:53+0000","dateFinished":"2017-08-21T20:09:07+0000","status":"FINISHED","progressUpdateIntervalMs":500,"$$hashKey":"object:4120"},{"title":"Run KMeans on GDELT Subset","text":"%sh\n# clear out potential old runs\ngeowave remote clear kmeans\n\n# run kmeans\ngeowave analytic kmeansspark gdelt kmeans -f gdeltevent --hulls --cqlFilter \"BBOX(geometry, 0, 50, 10, 60)\" -ch -ht myhulls -ct mycentroids\n","user":"anonymous","dateUpdated":"2017-08-21T20:13:07+0000","config":{"tableHide":false,"editorSetting":{"language":"sh","editOnDblClick":false},"colWidth":12,"editorMode":"ace/mode/sh","editorHide":false,"title":true,"results":{},"enabled":true},"settings":{"params":{},"forms":{}},"results":{"code":"INCOMPLETE","msg":[{"type":"TEXT","data":"21 Aug 20:13:08 WARN [util.NativeCodeLoader] - Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\nAug 21, 2017 8:13:10 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'GeoServerResourceLoader', but ApplicationContext is unset.\nAug 21, 2017 8:13:10 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'GeoServerResourceLoader', but ApplicationContext is unset.\nAug 21, 2017 8:13:10 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'ExtensionFilter', but ApplicationContext is unset.\nAug 21, 2017 8:13:10 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'ExtensionProvider', but ApplicationContext is unset.\nAug 21, 2017 8:13:10 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'ExtensionFilter', but ApplicationContext is unset.\nAug 21, 2017 8:13:10 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'GeoServerResourceLoader', but ApplicationContext is unset.\nAug 21, 2017 8:13:10 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'GeoServerResourceLoader', but ApplicationContext is unset.\nAug 21, 2017 8:13:10 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'ExtensionFilter', but ApplicationContext is unset.\nAug 21, 2017 8:13:10 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'ExtensionProvider', but ApplicationContext is unset.\nAug 21, 2017 8:13:10 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'ExtensionFilter', but ApplicationContext is unset.\n21 Aug 20:13:10 ERROR [persist.PersistableFactory] - '600' already registered for class 'mil.nga.giat.geowave.adapter.raster.Resolution'.  Cannot register 'class mil.nga.giat.geowave.format.twitter.TwitterIngestPlugin' with id '600'\n21 Aug 20:13:10 ERROR [persist.PersistableFactory] - '601' already registered for class 'mil.nga.giat.geowave.adapter.raster.adapter.CompoundHierarchicalIndexStrategyWrapper'.  Cannot register 'class mil.nga.giat.geowave.format.twitter.TwitterIngestPlugin$IngestTwitterFromHdfs' with id '601'\n21 Aug 20:13:11 WARN [util.NativeCodeLoader] - Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n21 Aug 20:14:25 WARN [scheduler.TaskSetManager] - Stage 0 contains a task of very large size (151 KB). The maximum recommended task size is 100 KB.\n\r[Stage 0:>                                                         (0 + 1) / 32]\r[Stage 0:=>                                                        (1 + 1) / 32]\r[Stage 0:=>                                                        (1 + 1) / 32]\r[Stage 0:===>                                                      (2 + 1) / 32]\r[Stage 0:===>                                                      (2 + 1) / 32]\r[Stage 0:=====>                                                    (3 + 1) / 32]\r[Stage 0:=====>                                                    (3 + 1) / 32]\r[Stage 0:=======>                                                  (4 + 1) / 32]\r[Stage 0:=======>                                                  (4 + 1) / 32]\r[Stage 0:=========>                                                (5 + 1) / 32]\r[Stage 0:=========>                                                (5 + 1) / 32]\r[Stage 0:==========>                                               (6 + 1) / 32]\r[Stage 0:==========>                                               (6 + 1) / 32]"},{"type":"TEXT","data":"Paragraph received a SIGTERM\nExitValue: 143"}]},"apps":[],"jobName":"paragraph_1503345355435_481233151","id":"20170809-194032_1817638679","dateCreated":"2017-08-21T19:55:55+0000","dateStarted":"2017-08-21T20:13:07+0000","dateFinished":"2017-08-21T20:23:07+0000","status":"FINISHED","progressUpdateIntervalMs":500,"$$hashKey":"object:4121"},{"title":"Add KMeans Results to GeoServer","text":"%sh\n\n# add the centroids layer\ngeowave gs addlayer kmeans -id mycentroids\ngeowave gs setls mycentroids --styleName point\n\n# add the hulls layer\ngeowave gs addlayer kmeans -id myhulls\ngeowave gs setls myhulls --styleName line","user":"anonymous","dateUpdated":"2017-08-21T21:22:00+0000","config":{"tableHide":false,"editorSetting":{"language":"sh","editOnDblClick":false},"colWidth":12,"editorMode":"ace/mode/sh","title":true,"results":{},"enabled":true},"settings":{"params":{},"forms":{}},"results":{"code":"SUCCESS","msg":[{"type":"TEXT","data":"21 Aug 21:21:48 DEBUG [util.Shell] - setsid exited with exit code 0\n21 Aug 21:21:48 DEBUG [security.Groups] -  Creating new Groups object\n21 Aug 21:21:48 DEBUG [util.NativeCodeLoader] - Trying to load the custom-built native-hadoop library...\n21 Aug 21:21:48 DEBUG [util.NativeCodeLoader] - Failed to load native-hadoop with error: java.lang.UnsatisfiedLinkError: no hadoop in java.library.path\n21 Aug 21:21:48 DEBUG [util.NativeCodeLoader] - java.library.path=/usr/java/packages/lib/amd64:/usr/lib64:/lib64:/lib:/usr/lib\n21 Aug 21:21:48 WARN [util.NativeCodeLoader] - Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n21 Aug 21:21:48 DEBUG [util.PerformanceAdvisory] - Falling back to shell based\n21 Aug 21:21:48 DEBUG [security.JniBasedUnixGroupsMappingWithFallback] - Group mapping impl=org.apache.hadoop.security.ShellBasedUnixGroupsMapping\n21 Aug 21:21:48 DEBUG [security.Groups] - Group mapping impl=org.apache.hadoop.security.JniBasedUnixGroupsMappingWithFallback; cacheTimeout=300000; warningDeltaMs=5000\n21 Aug 21:21:48 DEBUG [lib.MutableMetricsFactory] - field org.apache.hadoop.metrics2.lib.MutableRate org.apache.hadoop.security.UserGroupInformation$UgiMetrics.loginSuccess with annotation @org.apache.hadoop.metrics2.annotation.Metric(about=, sampleName=Ops, always=false, type=DEFAULT, valueName=Time, value=[Rate of successful kerberos logins and latency (milliseconds)])\n21 Aug 21:21:48 DEBUG [lib.MutableMetricsFactory] - field org.apache.hadoop.metrics2.lib.MutableRate org.apache.hadoop.security.UserGroupInformation$UgiMetrics.loginFailure with annotation @org.apache.hadoop.metrics2.annotation.Metric(about=, sampleName=Ops, always=false, type=DEFAULT, valueName=Time, value=[Rate of failed kerberos logins and latency (milliseconds)])\n21 Aug 21:21:48 DEBUG [lib.MutableMetricsFactory] - field org.apache.hadoop.metrics2.lib.MutableRate org.apache.hadoop.security.UserGroupInformation$UgiMetrics.getGroups with annotation @org.apache.hadoop.metrics2.annotation.Metric(about=, sampleName=Ops, always=false, type=DEFAULT, valueName=Time, value=[GetGroups])\n21 Aug 21:21:48 DEBUG [impl.MetricsSystemImpl] - UgiMetrics, User and group related metrics\n21 Aug 21:21:48 DEBUG [util.KerberosName] - Kerberos krb5 configuration not found, setting default realm to empty\n21 Aug 21:21:48 DEBUG [security.UserGroupInformation] - hadoop login\n21 Aug 21:21:48 DEBUG [security.UserGroupInformation] - hadoop login commit\n21 Aug 21:21:48 DEBUG [security.UserGroupInformation] - using local user:UnixPrincipal: zeppelin\n21 Aug 21:21:48 DEBUG [security.UserGroupInformation] - Using user: \"UnixPrincipal: zeppelin\" with name zeppelin\n21 Aug 21:21:48 DEBUG [security.UserGroupInformation] - User entry: \"zeppelin\"\n21 Aug 21:21:48 DEBUG [security.UserGroupInformation] - UGI loginUser:zeppelin (auth:SIMPLE)\n21 Aug 21:21:48 INFO [zookeeper.RecoverableZooKeeper] - Process identifier=hconnection-0x38afe297 connecting to ZooKeeper ensemble=ip-10-0-0-73:2181\n21 Aug 21:21:48 INFO [zookeeper.ZooKeeper] - Client environment:zookeeper.version=3.4.6-1569965, built on 02/20/2014 09:09 GMT\n21 Aug 21:21:48 INFO [zookeeper.ZooKeeper] - Client environment:host.name=ip-10-0-0-73.ec2.internal\n21 Aug 21:21:48 INFO [zookeeper.ZooKeeper] - Client environment:java.version=1.8.0_141\n21 Aug 21:21:48 INFO [zookeeper.ZooKeeper] - Client environment:java.vendor=Oracle Corporation\n21 Aug 21:21:48 INFO [zookeeper.ZooKeeper] - Client environment:java.home=/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.141-1.b16.32.amzn1.x86_64/jre\n21 Aug 21:21:48 INFO [zookeeper.ZooKeeper] - Client environment:java.class.path=/usr/local/geowave-0.9.6-apache/tools/geowave-tools-0.9.6-apache.jar:/usr/local/geowave-0.9.6-apache/tools/plugins/*\n21 Aug 21:21:48 INFO [zookeeper.ZooKeeper] - Client environment:java.library.path=/usr/java/packages/lib/amd64:/usr/lib64:/lib64:/lib:/usr/lib\n21 Aug 21:21:48 INFO [zookeeper.ZooKeeper] - Client environment:java.io.tmpdir=/tmp\n21 Aug 21:21:48 INFO [zookeeper.ZooKeeper] - Client environment:java.compiler=<NA>\n21 Aug 21:21:48 INFO [zookeeper.ZooKeeper] - Client environment:os.name=Linux\n21 Aug 21:21:48 INFO [zookeeper.ZooKeeper] - Client environment:os.arch=amd64\n21 Aug 21:21:48 INFO [zookeeper.ZooKeeper] - Client environment:os.version=4.4.35-33.55.amzn1.x86_64\n21 Aug 21:21:48 INFO [zookeeper.ZooKeeper] - Client environment:user.name=zeppelin\n21 Aug 21:21:48 INFO [zookeeper.ZooKeeper] - Client environment:user.home=/var/lib/zeppelin\n21 Aug 21:21:48 INFO [zookeeper.ZooKeeper] - Client environment:user.dir=/mnt/var/lib/zeppelin\n21 Aug 21:21:48 INFO [zookeeper.ZooKeeper] - Initiating client connection, connectString=ip-10-0-0-73:2181 sessionTimeout=90000 watcher=org.apache.hadoop.hbase.zookeeper.PendingWatcher@4e3958e7\n21 Aug 21:21:49 DEBUG [zookeeper.ClientCnxn] - zookeeper.disableAutoWatchReset is false\n21 Aug 21:21:49 INFO [zookeeper.ClientCnxn] - Opening socket connection to server ip-10-0-0-73.ec2.internal/10.0.0.73:2181. Will not attempt to authenticate using SASL (unknown error)\n21 Aug 21:21:49 INFO [zookeeper.ClientCnxn] - Socket connection established to ip-10-0-0-73.ec2.internal/10.0.0.73:2181, initiating session\n21 Aug 21:21:49 DEBUG [zookeeper.ClientCnxn] - Session establishment request sent on ip-10-0-0-73.ec2.internal/10.0.0.73:2181\n21 Aug 21:21:49 INFO [zookeeper.ClientCnxn] - Session establishment complete on server ip-10-0-0-73.ec2.internal/10.0.0.73:2181, sessionid = 0x15e064530cc001c, negotiated timeout = 40000\n21 Aug 21:21:49 DEBUG [zookeeper.ZooKeeperWatcher] - hconnection-0x38afe2970x0, quorum=ip-10-0-0-73:2181, baseZNode=/hbase Received ZooKeeper Event, type=None, state=SyncConnected, path=null\n21 Aug 21:21:49 DEBUG [zookeeper.ZooKeeperWatcher] - hconnection-0x38afe297-0x15e064530cc001c connected\n21 Aug 21:21:49 DEBUG [zookeeper.ClientCnxn] - Reading reply sessionid:0x15e064530cc001c, packet:: clientPath:null serverPath:null finished:false header:: 1,3  replyHeader:: 1,654,0  request:: '/hbase/hbaseid,F  response:: s{34,34,1503343780060,1503343780060,0,0,0,0,67,0,34} \n21 Aug 21:21:49 DEBUG [zookeeper.ClientCnxn] - Reading reply sessionid:0x15e064530cc001c, packet:: clientPath:null serverPath:null finished:false header:: 2,4  replyHeader:: 2,654,0  request:: '/hbase/hbaseid,F  response:: #ffffffff000146d61737465723a3136303030fffffffb36ffffff9e3dffffffe963ffffffe5fffffff550425546a2463653132386434362d343132342d343936352d626337662d663062383138666461626334,s{34,34,1503343780060,1503343780060,0,0,0,0,67,0,34} \n21 Aug 21:21:49 DEBUG [ipc.AbstractRpcClient] - Codec=org.apache.hadoop.hbase.codec.KeyValueCodec@2205a05d, compressor=null, tcpKeepAlive=true, tcpNoDelay=true, connectTO=10000, readTO=20000, writeTO=60000, minIdleTimeBeforeClose=120000, maxRetries=0, fallbackAllowed=false, bind address=null\n21 Aug 21:21:49 DEBUG [geoserver.GeoServerRestClient] - Adapter list for kmeans with adapterId = mycentroids: \n21 Aug 21:21:49 DEBUG [zookeeper.ClientCnxn] - Reading reply sessionid:0x15e064530cc001c, packet:: clientPath:null serverPath:null finished:false header:: 3,4  replyHeader:: 3,654,0  request:: '/hbase/meta-region-server,F  response:: #ffffffff0001a726567696f6e7365727665723a313630323071ffffffec3effffffa0fffffff25affffffc95b50425546a25a1969702d31302d302d302d39392e6563322e696e7465726e616c10ffffff947d18ffffff92ffffff88ffffff95ffffffb2ffffffe02b100183,s{87,87,1503343786729,1503343786729,0,0,0,0,78,0,87} \n21 Aug 21:21:49 DEBUG [zookeeper.ClientCnxn] - Reading reply sessionid:0x15e064530cc001c, packet:: clientPath:null serverPath:null finished:false header:: 4,8  replyHeader:: 4,654,0  request:: '/hbase,F  response:: v{'replication,'meta-region-server,'rs,'splitWAL,'backup-masters,'table-lock,'flush-table-proc,'region-in-transition,'online-snapshot,'master,'switch,'running,'recovering-regions,'draining,'namespace,'hbaseid,'table} \n21 Aug 21:21:49 DEBUG [ipc.RpcClientImpl] - Use SIMPLE authentication for service ClientService, sasl=false\n21 Aug 21:21:49 DEBUG [ipc.RpcClientImpl] - Connecting to ip-10-0-0-99.ec2.internal/10.0.0.99:16020\n21 Aug 21:21:49 DEBUG [ipc.RpcClientImpl] - Use SIMPLE authentication for service ClientService, sasl=false\n21 Aug 21:21:49 DEBUG [ipc.RpcClientImpl] - Connecting to ip-10-0-0-153.ec2.internal/10.0.0.153:16020\nAug 21, 2017 9:21:50 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'GeoServerResourceLoader', but ApplicationContext is unset.\nAug 21, 2017 9:21:50 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'GeoServerResourceLoader', but ApplicationContext is unset.\nAug 21, 2017 9:21:50 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'ExtensionFilter', but ApplicationContext is unset.\nAug 21, 2017 9:21:50 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'ExtensionProvider', but ApplicationContext is unset.\nAug 21, 2017 9:21:50 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'ExtensionFilter', but ApplicationContext is unset.\nAug 21, 2017 9:21:50 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'GeoServerResourceLoader', but ApplicationContext is unset.\nAug 21, 2017 9:21:51 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'GeoServerResourceLoader', but ApplicationContext is unset.\nAug 21, 2017 9:21:51 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'ExtensionFilter', but ApplicationContext is unset.\nAug 21, 2017 9:21:51 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'ExtensionProvider', but ApplicationContext is unset.\nAug 21, 2017 9:21:51 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'ExtensionFilter', but ApplicationContext is unset.\n21 Aug 21:21:51 ERROR [persist.PersistableFactory] - '600' already registered for class 'mil.nga.giat.geowave.adapter.raster.Resolution'.  Cannot register 'class mil.nga.giat.geowave.format.twitter.TwitterIngestPlugin' with id '600'\n21 Aug 21:21:51 ERROR [persist.PersistableFactory] - '601' already registered for class 'mil.nga.giat.geowave.adapter.raster.adapter.CompoundHierarchicalIndexStrategyWrapper'.  Cannot register 'class mil.nga.giat.geowave.format.twitter.TwitterIngestPlugin$IngestTwitterFromHdfs' with id '601'\n21 Aug 21:21:51 INFO [util.FeatureDataUtils] - Generating patched classloader\n21 Aug 21:21:51 DEBUG [geoserver.GeoServerRestClient] - getAdapterInfo for id = mycentroids\n21 Aug 21:21:51 DEBUG [geoserver.GeoServerRestClient] - > Adapter ID: mycentroids\n21 Aug 21:21:51 DEBUG [geoserver.GeoServerRestClient] - > Adapter Type: FeatureDataAdapter\n21 Aug 21:21:51 DEBUG [geoserver.GeoServerRestClient] - id matches adapter id\n21 Aug 21:21:51 DEBUG [geoserver.GeoServerRestClient] - > 'mycentroids' adapter passed filter\n21 Aug 21:21:51 DEBUG [geoserver.GeoServerRestClient] - getAdapterInfo for id = mycentroids\n21 Aug 21:21:51 DEBUG [geoserver.GeoServerRestClient] - > Adapter ID: myhulls\n21 Aug 21:21:51 DEBUG [geoserver.GeoServerRestClient] - > Adapter Type: FeatureDataAdapter\n21 Aug 21:21:51 DEBUG [geoserver.GeoServerRestClient] - No match!\n21 Aug 21:21:51 DEBUG [geoserver.GeoServerRestClient] - getStoreAdapterInfo(kmeans) got 1 ids\n21 Aug 21:21:51 DEBUG [geoserver.GeoServerRestClient] - Finished retrieving adapter list\n21 Aug 21:21:52 DEBUG [geoserver.GeoServerRestClient] - Checking for existing feature layer: mycentroids\n21 Aug 21:21:52 DEBUG [geoserver.GeoServerRestClient] - Get feature layer: mycentroids returned 404\nAdd GeoServer layer for 'kmeans: OK\n{\n  \"description\": \"Successfully added:\",\n  \"layers\": [  {\n    \"id\": \"mycentroids\",\n    \"type\": \"vector\"\n  }]\n}\nSet style for GeoServer layer 'mycentroids: OK\n\n21 Aug 21:21:54 DEBUG [util.Shell] - setsid exited with exit code 0\n21 Aug 21:21:54 DEBUG [security.Groups] -  Creating new Groups object\n21 Aug 21:21:54 DEBUG [util.NativeCodeLoader] - Trying to load the custom-built native-hadoop library...\n21 Aug 21:21:54 DEBUG [util.NativeCodeLoader] - Failed to load native-hadoop with error: java.lang.UnsatisfiedLinkError: no hadoop in java.library.path\n21 Aug 21:21:54 DEBUG [util.NativeCodeLoader] - java.library.path=/usr/java/packages/lib/amd64:/usr/lib64:/lib64:/lib:/usr/lib\n21 Aug 21:21:54 WARN [util.NativeCodeLoader] - Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n21 Aug 21:21:54 DEBUG [util.PerformanceAdvisory] - Falling back to shell based\n21 Aug 21:21:54 DEBUG [security.JniBasedUnixGroupsMappingWithFallback] - Group mapping impl=org.apache.hadoop.security.ShellBasedUnixGroupsMapping\n21 Aug 21:21:54 DEBUG [security.Groups] - Group mapping impl=org.apache.hadoop.security.JniBasedUnixGroupsMappingWithFallback; cacheTimeout=300000; warningDeltaMs=5000\n21 Aug 21:21:54 DEBUG [lib.MutableMetricsFactory] - field org.apache.hadoop.metrics2.lib.MutableRate org.apache.hadoop.security.UserGroupInformation$UgiMetrics.loginSuccess with annotation @org.apache.hadoop.metrics2.annotation.Metric(about=, sampleName=Ops, always=false, type=DEFAULT, valueName=Time, value=[Rate of successful kerberos logins and latency (milliseconds)])\n21 Aug 21:21:54 DEBUG [lib.MutableMetricsFactory] - field org.apache.hadoop.metrics2.lib.MutableRate org.apache.hadoop.security.UserGroupInformation$UgiMetrics.loginFailure with annotation @org.apache.hadoop.metrics2.annotation.Metric(about=, sampleName=Ops, always=false, type=DEFAULT, valueName=Time, value=[Rate of failed kerberos logins and latency (milliseconds)])\n21 Aug 21:21:54 DEBUG [lib.MutableMetricsFactory] - field org.apache.hadoop.metrics2.lib.MutableRate org.apache.hadoop.security.UserGroupInformation$UgiMetrics.getGroups with annotation @org.apache.hadoop.metrics2.annotation.Metric(about=, sampleName=Ops, always=false, type=DEFAULT, valueName=Time, value=[GetGroups])\n21 Aug 21:21:54 DEBUG [impl.MetricsSystemImpl] - UgiMetrics, User and group related metrics\n21 Aug 21:21:54 DEBUG [util.KerberosName] - Kerberos krb5 configuration not found, setting default realm to empty\n21 Aug 21:21:54 DEBUG [security.UserGroupInformation] - hadoop login\n21 Aug 21:21:54 DEBUG [security.UserGroupInformation] - hadoop login commit\n21 Aug 21:21:54 DEBUG [security.UserGroupInformation] - using local user:UnixPrincipal: zeppelin\n21 Aug 21:21:54 DEBUG [security.UserGroupInformation] - Using user: \"UnixPrincipal: zeppelin\" with name zeppelin\n21 Aug 21:21:54 DEBUG [security.UserGroupInformation] - User entry: \"zeppelin\"\n21 Aug 21:21:54 DEBUG [security.UserGroupInformation] - UGI loginUser:zeppelin (auth:SIMPLE)\n21 Aug 21:21:54 INFO [zookeeper.RecoverableZooKeeper] - Process identifier=hconnection-0x38afe297 connecting to ZooKeeper ensemble=ip-10-0-0-73:2181\n21 Aug 21:21:54 INFO [zookeeper.ZooKeeper] - Client environment:zookeeper.version=3.4.6-1569965, built on 02/20/2014 09:09 GMT\n21 Aug 21:21:54 INFO [zookeeper.ZooKeeper] - Client environment:host.name=ip-10-0-0-73.ec2.internal\n21 Aug 21:21:54 INFO [zookeeper.ZooKeeper] - Client environment:java.version=1.8.0_141\n21 Aug 21:21:54 INFO [zookeeper.ZooKeeper] - Client environment:java.vendor=Oracle Corporation\n21 Aug 21:21:54 INFO [zookeeper.ZooKeeper] - Client environment:java.home=/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.141-1.b16.32.amzn1.x86_64/jre\n21 Aug 21:21:54 INFO [zookeeper.ZooKeeper] - Client environment:java.class.path=/usr/local/geowave-0.9.6-apache/tools/geowave-tools-0.9.6-apache.jar:/usr/local/geowave-0.9.6-apache/tools/plugins/*\n21 Aug 21:21:54 INFO [zookeeper.ZooKeeper] - Client environment:java.library.path=/usr/java/packages/lib/amd64:/usr/lib64:/lib64:/lib:/usr/lib\n21 Aug 21:21:54 INFO [zookeeper.ZooKeeper] - Client environment:java.io.tmpdir=/tmp\n21 Aug 21:21:54 INFO [zookeeper.ZooKeeper] - Client environment:java.compiler=<NA>\n21 Aug 21:21:54 INFO [zookeeper.ZooKeeper] - Client environment:os.name=Linux\n21 Aug 21:21:54 INFO [zookeeper.ZooKeeper] - Client environment:os.arch=amd64\n21 Aug 21:21:54 INFO [zookeeper.ZooKeeper] - Client environment:os.version=4.4.35-33.55.amzn1.x86_64\n21 Aug 21:21:54 INFO [zookeeper.ZooKeeper] - Client environment:user.name=zeppelin\n21 Aug 21:21:54 INFO [zookeeper.ZooKeeper] - Client environment:user.home=/var/lib/zeppelin\n21 Aug 21:21:54 INFO [zookeeper.ZooKeeper] - Client environment:user.dir=/mnt/var/lib/zeppelin\n21 Aug 21:21:54 INFO [zookeeper.ZooKeeper] - Initiating client connection, connectString=ip-10-0-0-73:2181 sessionTimeout=90000 watcher=org.apache.hadoop.hbase.zookeeper.PendingWatcher@4e3958e7\n21 Aug 21:21:54 DEBUG [zookeeper.ClientCnxn] - zookeeper.disableAutoWatchReset is false\n21 Aug 21:21:54 INFO [zookeeper.ClientCnxn] - Opening socket connection to server ip-10-0-0-73.ec2.internal/10.0.0.73:2181. Will not attempt to authenticate using SASL (unknown error)\n21 Aug 21:21:54 INFO [zookeeper.ClientCnxn] - Socket connection established to ip-10-0-0-73.ec2.internal/10.0.0.73:2181, initiating session\n21 Aug 21:21:54 DEBUG [zookeeper.ClientCnxn] - Session establishment request sent on ip-10-0-0-73.ec2.internal/10.0.0.73:2181\n21 Aug 21:21:54 INFO [zookeeper.ClientCnxn] - Session establishment complete on server ip-10-0-0-73.ec2.internal/10.0.0.73:2181, sessionid = 0x15e064530cc001d, negotiated timeout = 40000\n21 Aug 21:21:54 DEBUG [zookeeper.ZooKeeperWatcher] - hconnection-0x38afe2970x0, quorum=ip-10-0-0-73:2181, baseZNode=/hbase Received ZooKeeper Event, type=None, state=SyncConnected, path=null\n21 Aug 21:21:54 DEBUG [zookeeper.ZooKeeperWatcher] - hconnection-0x38afe297-0x15e064530cc001d connected\n21 Aug 21:21:54 DEBUG [zookeeper.ClientCnxn] - Reading reply sessionid:0x15e064530cc001d, packet:: clientPath:null serverPath:null finished:false header:: 1,3  replyHeader:: 1,655,0  request:: '/hbase/hbaseid,F  response:: s{34,34,1503343780060,1503343780060,0,0,0,0,67,0,34} \n21 Aug 21:21:54 DEBUG [zookeeper.ClientCnxn] - Reading reply sessionid:0x15e064530cc001d, packet:: clientPath:null serverPath:null finished:false header:: 2,4  replyHeader:: 2,655,0  request:: '/hbase/hbaseid,F  response:: #ffffffff000146d61737465723a3136303030fffffffb36ffffff9e3dffffffe963ffffffe5fffffff550425546a2463653132386434362d343132342d343936352d626337662d663062383138666461626334,s{34,34,1503343780060,1503343780060,0,0,0,0,67,0,34} \n21 Aug 21:21:55 DEBUG [ipc.AbstractRpcClient] - Codec=org.apache.hadoop.hbase.codec.KeyValueCodec@2205a05d, compressor=null, tcpKeepAlive=true, tcpNoDelay=true, connectTO=10000, readTO=20000, writeTO=60000, minIdleTimeBeforeClose=120000, maxRetries=0, fallbackAllowed=false, bind address=null\n21 Aug 21:21:55 DEBUG [geoserver.GeoServerRestClient] - Adapter list for kmeans with adapterId = myhulls: \n21 Aug 21:21:55 DEBUG [zookeeper.ClientCnxn] - Reading reply sessionid:0x15e064530cc001d, packet:: clientPath:null serverPath:null finished:false header:: 3,4  replyHeader:: 3,655,0  request:: '/hbase/meta-region-server,F  response:: #ffffffff0001a726567696f6e7365727665723a313630323071ffffffec3effffffa0fffffff25affffffc95b50425546a25a1969702d31302d302d302d39392e6563322e696e7465726e616c10ffffff947d18ffffff92ffffff88ffffff95ffffffb2ffffffe02b100183,s{87,87,1503343786729,1503343786729,0,0,0,0,78,0,87} \n21 Aug 21:21:55 DEBUG [zookeeper.ClientCnxn] - Reading reply sessionid:0x15e064530cc001d, packet:: clientPath:null serverPath:null finished:false header:: 4,8  replyHeader:: 4,655,0  request:: '/hbase,F  response:: v{'replication,'meta-region-server,'rs,'splitWAL,'backup-masters,'table-lock,'flush-table-proc,'region-in-transition,'online-snapshot,'master,'switch,'running,'recovering-regions,'draining,'namespace,'hbaseid,'table} \n21 Aug 21:21:55 DEBUG [ipc.RpcClientImpl] - Use SIMPLE authentication for service ClientService, sasl=false\n21 Aug 21:21:55 DEBUG [ipc.RpcClientImpl] - Connecting to ip-10-0-0-99.ec2.internal/10.0.0.99:16020\n21 Aug 21:21:55 DEBUG [ipc.RpcClientImpl] - Use SIMPLE authentication for service ClientService, sasl=false\n21 Aug 21:21:55 DEBUG [ipc.RpcClientImpl] - Connecting to ip-10-0-0-153.ec2.internal/10.0.0.153:16020\nAug 21, 2017 9:21:56 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'GeoServerResourceLoader', but ApplicationContext is unset.\nAug 21, 2017 9:21:56 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'GeoServerResourceLoader', but ApplicationContext is unset.\nAug 21, 2017 9:21:56 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'ExtensionFilter', but ApplicationContext is unset.\nAug 21, 2017 9:21:56 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'ExtensionProvider', but ApplicationContext is unset.\nAug 21, 2017 9:21:56 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'ExtensionFilter', but ApplicationContext is unset.\nAug 21, 2017 9:21:56 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'GeoServerResourceLoader', but ApplicationContext is unset.\nAug 21, 2017 9:21:56 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'GeoServerResourceLoader', but ApplicationContext is unset.\nAug 21, 2017 9:21:56 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'ExtensionFilter', but ApplicationContext is unset.\nAug 21, 2017 9:21:56 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'ExtensionProvider', but ApplicationContext is unset.\nAug 21, 2017 9:21:56 PM org.geoserver.platform.GeoServerExtensions checkContext\nWARNING: Extension lookup 'ExtensionFilter', but ApplicationContext is unset.\n21 Aug 21:21:56 ERROR [persist.PersistableFactory] - '600' already registered for class 'mil.nga.giat.geowave.adapter.raster.Resolution'.  Cannot register 'class mil.nga.giat.geowave.format.twitter.TwitterIngestPlugin' with id '600'\n21 Aug 21:21:56 ERROR [persist.PersistableFactory] - '601' already registered for class 'mil.nga.giat.geowave.adapter.raster.adapter.CompoundHierarchicalIndexStrategyWrapper'.  Cannot register 'class mil.nga.giat.geowave.format.twitter.TwitterIngestPlugin$IngestTwitterFromHdfs' with id '601'\n21 Aug 21:21:56 INFO [util.FeatureDataUtils] - Generating patched classloader\n21 Aug 21:21:56 DEBUG [geoserver.GeoServerRestClient] - getAdapterInfo for id = myhulls\n21 Aug 21:21:56 DEBUG [geoserver.GeoServerRestClient] - > Adapter ID: mycentroids\n21 Aug 21:21:56 DEBUG [geoserver.GeoServerRestClient] - > Adapter Type: FeatureDataAdapter\n21 Aug 21:21:56 DEBUG [geoserver.GeoServerRestClient] - No match!\n21 Aug 21:21:56 DEBUG [geoserver.GeoServerRestClient] - getAdapterInfo for id = myhulls\n21 Aug 21:21:56 DEBUG [geoserver.GeoServerRestClient] - > Adapter ID: myhulls\n21 Aug 21:21:56 DEBUG [geoserver.GeoServerRestClient] - > Adapter Type: FeatureDataAdapter\n21 Aug 21:21:56 DEBUG [geoserver.GeoServerRestClient] - id matches adapter id\n21 Aug 21:21:56 DEBUG [geoserver.GeoServerRestClient] - > 'myhulls' adapter passed filter\n21 Aug 21:21:56 DEBUG [geoserver.GeoServerRestClient] - getStoreAdapterInfo(kmeans) got 1 ids\n21 Aug 21:21:56 DEBUG [geoserver.GeoServerRestClient] - Finished retrieving adapter list\n21 Aug 21:21:57 DEBUG [geoserver.GeoServerRestClient] - Checking for existing feature layer: myhulls\n21 Aug 21:21:57 DEBUG [geoserver.GeoServerRestClient] - Get feature layer: myhulls returned 404\nAdd GeoServer layer for 'kmeans: OK\n{\n  \"description\": \"Successfully added:\",\n  \"layers\": [  {\n    \"id\": \"myhulls\",\n    \"type\": \"vector\"\n  }]\n}\nSet style for GeoServer layer 'myhulls: OK\n\n"}]},"apps":[],"jobName":"paragraph_1503345355436_479309407","id":"20170817-030121_1271873891","dateCreated":"2017-08-21T19:55:55+0000","dateStarted":"2017-08-21T21:21:47+0000","dateFinished":"2017-08-21T21:21:58+0000","status":"FINISHED","progressUpdateIntervalMs":500,"$$hashKey":"object:4122"},{"text":"%angular\n<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.css\" />\n<h3>GeoWave Leaflet Map</h3>\n<div id=\"map\" style=\"height: 600px; width: 100%\"></div>\n\n<script type=\"text/javascript\">\n\n\nfunction initMap() {\n    var map = L.map('map').setView([50.00, 10.00], 5);\n    \n    var host='ec2-52-55-84-142.compute-1.amazonaws.com';\n    mapLink = '<a href=\"http://www.esri.com/\">Esri</a>';\n    wholink = 'i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community';\n\n    var basemaps = {\n        OSM: L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {\n            attribution: 'Map data &copy; <a href=\"http://openstreetmap.org\">OpenStreetMap</a> contributors',\n            maxZoom: 15,\n            minZoom: 2\n        }),\n        Satellite:L.tileLayer(\n            'http://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {\n            attribution: '&copy; '+mapLink+', '+wholink,\n            maxZoom: 18,\n        }),\n        LANDSAT: L.tileLayer.wms('http://'+host+':8000/geoserver/geowave/wms?', {\n            layers: 'geowave:germany_mosaic',\n            format: 'image/jpeg'\n        })\n    };\n    \n    var overlays = {\n        GDELT:L.tileLayer.wms('http://'+host+':8000/geoserver/geowave/wms?', {\n            layers: 'geowave:gdeltevent',\n            format: 'image/png',\n            transparent: true\n        }),\n        \n        KMeansCentroids:L.tileLayer.wms('http://'+host+':8000/geoserver/geowave/wms?', {\n            layers: 'geowave:mycentroids',\n            format: 'image/png',\n            transparent: true\n        }),\n        \n        KMeansHulls:L.tileLayer.wms('http://'+host+':8000/geoserver/geowave/wms?', {\n            layers: 'geowave:myhulls',\n            format: 'image/png',\n            transparent: true\n        })\n    };\n\n    L.control.layers(basemaps, overlays).addTo(map);\n    \n    basemaps.OSM.addTo(map);\n}\n\n// ensure we only load the script once, seems to cause issues otherwise\nif (window.L) {\n    initMap();\n} else {\n    console.log('Loading Leaflet library');\n    var sc = document.createElement('script');\n    sc.type = 'text/javascript';\n    sc.src = 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.js';\n    sc.onload = initMap;\n    sc.onerror = function(err) { alert(err); }\n    document.getElementsByTagName('head')[0].appendChild(sc);\n}\n</script>\n","user":"anonymous","dateUpdated":"2017-08-21T20:11:30+0000","config":{"tableHide":false,"editorSetting":{"language":"scala","editOnDblClick":true},"colWidth":12,"editorMode":"ace/mode/undefined","editorHide":true,"results":{},"enabled":true},"settings":{"params":{},"forms":{}},"results":{"code":"SUCCESS","msg":[{"type":"ANGULAR","data":"<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.css\" />\n<h3>GeoWave Leaflet Map</h3>\n<div id=\"map\" style=\"height: 600px; width: 100%\"></div>\n\n<script type=\"text/javascript\">\n\n\nfunction initMap() {\n    var map = L.map('map').setView([50.00, 10.00], 5);\n    \n    var host='ec2-52-55-84-142.compute-1.amazonaws.com';\n    mapLink = '<a href=\"http://www.esri.com/\">Esri</a>';\n    wholink = 'i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community';\n\n    var basemaps = {\n        OSM: L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {\n            attribution: 'Map data &copy; <a href=\"http://openstreetmap.org\">OpenStreetMap</a> contributors',\n            maxZoom: 15,\n            minZoom: 2\n        }),\n        Satellite:L.tileLayer(\n            'http://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {\n            attribution: '&copy; '+mapLink+', '+wholink,\n            maxZoom: 18,\n        }),\n        LANDSAT: L.tileLayer.wms('http://'+host+':8000/geoserver/geowave/wms?', {\n            layers: 'geowave:germany_mosaic',\n            format: 'image/jpeg'\n        })\n    };\n    \n    var overlays = {\n        GDELT:L.tileLayer.wms('http://'+host+':8000/geoserver/geowave/wms?', {\n            layers: 'geowave:gdeltevent',\n            format: 'image/png',\n            transparent: true\n        }),\n        \n        KMeansCentroids:L.tileLayer.wms('http://'+host+':8000/geoserver/geowave/wms?', {\n            layers: 'geowave:mycentroids',\n            format: 'image/png',\n            transparent: true\n        }),\n        \n        KMeansHulls:L.tileLayer.wms('http://'+host+':8000/geoserver/geowave/wms?', {\n            layers: 'geowave:myhulls',\n            format: 'image/png',\n            transparent: true\n        })\n    };\n\n    L.control.layers(basemaps, overlays).addTo(map);\n    \n    basemaps.OSM.addTo(map);\n}\n\n// ensure we only load the script once, seems to cause issues otherwise\nif (window.L) {\n    initMap();\n} else {\n    console.log('Loading Leaflet library');\n    var sc = document.createElement('script');\n    sc.type = 'text/javascript';\n    sc.src = 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.js';\n    sc.onload = initMap;\n    sc.onerror = function(err) { alert(err); }\n    document.getElementsByTagName('head')[0].appendChild(sc);\n}\n</script>"}]},"apps":[],"jobName":"paragraph_1503345355438_480078904","id":"20170817-030613_874309201","dateCreated":"2017-08-21T19:55:55+0000","dateStarted":"2017-08-21T20:11:30+0000","dateFinished":"2017-08-21T20:11:30+0000","status":"FINISHED","progressUpdateIntervalMs":500,"$$hashKey":"object:4123"},{"title":"Export KMeans Hulls to CSV","text":"%sh\n# Set up the temp folder\ncd /mnt/tmp\nrm -rf kmeans\nmkdir kmeans\n\n# Query kmeans centroids and write to local temp file\ngeowave analytic sql \"select * from kmeans|myhulls\" --csv /mnt/tmp/kmeans\n\n# Move the csv output to hdfs\nmv kmeans/part*.csv mykmeans.csv\nhdfs dfs -rm /user/zeppelin/mykmeans.csv\nhdfs dfs -put mykmeans.csv /user/zeppelin/mykmeans.csv","user":"anonymous","dateUpdated":"2017-08-21T22:21:28+0000","config":{"tableHide":false,"editorSetting":{"language":"sh","editOnDblClick":false},"colWidth":12,"editorMode":"ace/mode/sh","editorHide":false,"title":true,"results":{},"enabled":true},"settings":{"params":{},"forms":{}},"results":{"code":"SUCCESS","msg":[{"type":"TEXT","data":"21 Aug 22:21:29 WARN [util.NativeCodeLoader] - Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n21 Aug 22:21:30 WARN [util.Utils] - Service 'SparkUI' could not bind on port 4040. Attempting port 4041.\n21 Aug 22:21:32 WARN [geoserver.platform] - Extension lookup 'GeoServerResourceLoader', but ApplicationContext is unset.\n21 Aug 22:21:32 WARN [geoserver.platform] - Extension lookup 'GeoServerResourceLoader', but ApplicationContext is unset.\n21 Aug 22:21:32 WARN [geoserver.platform] - Extension lookup 'ExtensionFilter', but ApplicationContext is unset.\n21 Aug 22:21:32 WARN [geoserver.platform] - Extension lookup 'ExtensionProvider', but ApplicationContext is unset.\n21 Aug 22:21:32 WARN [geoserver.platform] - Extension lookup 'ExtensionFilter', but ApplicationContext is unset.\n21 Aug 22:21:32 WARN [geoserver.platform] - Extension lookup 'GeoServerResourceLoader', but ApplicationContext is unset.\n21 Aug 22:21:32 WARN [geoserver.platform] - Extension lookup 'GeoServerResourceLoader', but ApplicationContext is unset.\n21 Aug 22:21:32 WARN [geoserver.platform] - Extension lookup 'ExtensionFilter', but ApplicationContext is unset.\n21 Aug 22:21:32 WARN [geoserver.platform] - Extension lookup 'ExtensionProvider', but ApplicationContext is unset.\n21 Aug 22:21:32 WARN [geoserver.platform] - Extension lookup 'ExtensionFilter', but ApplicationContext is unset.\n21 Aug 22:21:32 ERROR [persist.PersistableFactory] - '600' already registered for class 'mil.nga.giat.geowave.adapter.raster.Resolution'.  Cannot register 'class mil.nga.giat.geowave.format.twitter.TwitterIngestPlugin' with id '600'\n21 Aug 22:21:32 ERROR [persist.PersistableFactory] - '601' already registered for class 'mil.nga.giat.geowave.adapter.raster.adapter.CompoundHierarchicalIndexStrategyWrapper'.  Cannot register 'class mil.nga.giat.geowave.format.twitter.TwitterIngestPlugin$IngestTwitterFromHdfs' with id '601'\n\r[Stage 0:>                                                          (0 + 0) / 2]\r[Stage 0:=============================>                             (1 + 1) / 2]\r                                                                                \r+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------+-------+---------------------+---------------------+\n|geom                                                                                                                                                                                                                                                                                                                                                              |ClusterIndex|Count  |Area                 |Density              |\n+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------+-------+---------------------+---------------------+\n|POLYGON ((-176.067 -44.3333, -176.217 -44.2333, -176.5 -44, -176.533 -43.95, -179.967 -16.85, -179.983 -16.1667, -179.667 71.25, -114 76.8333, -112 75.5, -110 71, -108.883 67.4167, -107.95 59.2, -107.75 54.9333, -107.767 53.1333, -108.449 39.0921, -108.833 31.3333, -109.117 26.45, -109.425 23.4456, -110.967 18.75, -130.083 -25.0667, -176.067 -44.3333))|3           |387962 |4.0115850428498507E8 |9.671040146375404E-4 |\n|POLYGON ((-67.2667 -55.9833, -130 -45, -85.8367 10.3892, -85.6962 10.5525, -83.6585 11.5945, -63.2667 18.2833, -25 16.8833, -24 16, -23.5167 14.9167, -25 10, -39.8167 -19.6, -57.85 -51.7, -64.25 -54.7833, -67.2667 -55.9833))                                                                                                                                  |4           |115539 |2.0908055080757553E11|5.526052019364286E-7 |\n|POLYGON ((32.3438 -85.6221, -12.2833 -37.0833, -17.6339 14.7367, -17.0336 20.9002, -12.8119 22.8772, 42.3833 19.1167, 42.9853 19.0639, 54.3918 17.0389, 57.7144 -20.1897, 57.7267 -20.4172, 32.3438 -85.6221))                                                                                                                                                    |5           |538828 |8.933931988110149E10 |6.0312525405063186E-6|\n|POLYGON ((105.676 -10.5198, 70 -10, 57 21, 57.2642 23.2375, 59.6742 35.2127, 66.4183 66.6572, 70 70, 80 76, 142 75, 171.633 69.9, 177.6 64.7833, 173.238 52.9375, 125.131 1.4418, 120.038 -3.2176, 114.356 -8.2353, 113.879 -8.5315, 105.676 -10.5198))                                                                                                           |2           |1053522|1.731963442166877E8  |0.006082818923024888 |\n|POLYGON ((158.86 -54.61, 115.168 -34.3478, 115.017 -34.225, 113.133 -26.1333, 114.595 -8.3505, 119.584 -3.6952, 125.182 1.4451, 144.888 19.4355, 169.933 10.3333, 180 0, 180 -18.5, 179.05 -47.75, 169.083 -52.5, 158.86 -54.61))                                                                                                                                 |0           |212217 |4.432184030486991E7  |0.004788090894697854 |\n|POLYGON ((-85.7056 10.7385, -101.017 17.3167, -103.717 18.6, -104.783 19.2667, -105.483 19.9833, -108.983 25.4833, -109.05 25.6, -108.6 35.5339, -108.518 37.2717, -108.217 43.5858, -107.617 55.15, -105.567 75.6167, -95 77.6667, -90.8333 77.2833, -90 75, -87.7833 54.8167, -86.9671 45.9269, -86.502 39.7619, -84.4562 11.6876, -85.7056 10.7385))           |6           |749083 |1.0867836612952123E9 |6.892659750766351E-4 |\n|POLYGON ((42.6667 19.1333, -15.9532 23.6609, -27.0667 38.7333, -23.7305 65.637, -21.9667 70.4833, 0 85, 55 81, 58 80.1667, 62.8689 61.1947, 63.9037 56.6038, 59.2409 33.3723, 57.2525 23.7656, 56.5167 20.8833, 53.3333 19.3333, 42.6667 19.1333))                                                                                                                |7           |1830244|2.2347503902920425E10|8.189925854586469E-5 |\n|POLYGON ((-83.7635 12.0137, -84.2979 12.3181, -85.8497 30.9193, -86.42 38.7334, -86.901 45.3772, -87.5667 56.0667, -88.5833 78.3, -88 80.8333, -59.5 80.5, -31 70, -28 38.5, -28.1333 38.4167, -63.6667 18.5, -83.0418 12.1694, -83.7635 12.0137))                                                                                                                |1           |1088884|4.008368251353978E7  |0.02716526855116638  |\n+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------+-------+---------------------+---------------------+\n\nGeoWave SparkSQL query returned 8 results\n17/08/21 22:21:39 INFO fs.TrashPolicyDefault: Namenode trash configuration: Deletion interval = 0 minutes, Emptier interval = 0 minutes.\nDeleted /user/zeppelin/mykmeans.csv\n"}]},"apps":[],"jobName":"paragraph_1503345355439_479694155","id":"20170809-201803_119430460","dateCreated":"2017-08-21T19:55:55+0000","dateStarted":"2017-08-21T22:21:28+0000","dateFinished":"2017-08-21T22:21:42+0000","status":"FINISHED","progressUpdateIntervalMs":500,"$$hashKey":"object:4124"},{"title":"Load KMeans Hull CSV into DataFrame","text":"// load centroid data from hdfs\nval kmeansText = sc.textFile(\"/user/zeppelin/mykmeans.csv\")\n\ncase class KMeansRow(index: Int, count: Int, area: Double, density: Double)\n\n// split each line, filter out header (starts with \"geom\"), and map it into data class\nval kmeansData = kmeansText.map(s=>s.split(\",(?=([^\\\"]*\\\"[^\\\"]*\\\")*[^\\\"]*$)\")).filter(s=>s(0)!=\"geom\").map(\n    s=>KMeansRow(s(1).toInt, s(2).toInt, s(3).toDouble, s(4).toDouble)\n)\n\n// send the results to the front end (Leaflet map)\nz.angularBind(\"pins\", kmeansData.collect())\n\n// register a view for SQL queries\nkmeansData.toDF().registerTempTable(\"kmeans\")\n","user":"anonymous","dateUpdated":"2017-08-21T22:26:06+0000","config":{"tableHide":false,"editorSetting":{"language":"scala","editOnDblClick":false},"colWidth":12,"editorMode":"ace/mode/scala","editorHide":false,"title":true,"results":{},"enabled":true},"settings":{"params":{},"forms":{}},"results":{"code":"SUCCESS","msg":[{"type":"TEXT","data":"\nkmeansText: org.apache.spark.rdd.RDD[String] = /user/zeppelin/mykmeans.csv MapPartitionsRDD[23] at textFile at <console>:28\n\ndefined class KMeansRow\n\nkmeansData: org.apache.spark.rdd.RDD[KMeansRow] = MapPartitionsRDD[26] at map at <console>:31\n\nwarning: there was one deprecation warning; re-run with -deprecation for details\n"}]},"apps":[],"jobName":"paragraph_1503345355440_490082376","id":"20170814-174640_830156690","dateCreated":"2017-08-21T19:55:55+0000","dateStarted":"2017-08-21T22:26:06+0000","dateFinished":"2017-08-21T22:26:16+0000","status":"FINISHED","progressUpdateIntervalMs":500,"$$hashKey":"object:4125"},{"title":"Display the KMeans Hulls Table","text":"%sql\nselect * from kmeans order by density","dateUpdated":"2017-08-21T22:30:57+0000","config":{"editorSetting":{"language":"sql","editOnDblClick":false},"colWidth":8,"editorMode":"ace/mode/sql","editorHide":false,"title":true,"results":{"0":{"graph":{"mode":"table","height":300,"optionOpen":false},"helium":{}}},"enabled":true},"settings":{"params":{},"forms":{}},"results":{"code":"SUCCESS","msg":[{"type":"TABLE","data":"index\tcount\tarea\tdensity\n4\t115539\t2.0908055080757553E11\t5.526052019364286E-7\n5\t538828\t8.933931988110149E10\t6.0312525405063186E-6\n7\t1830244\t2.2347503902920425E10\t8.189925854586469E-5\n6\t749083\t1.0867836612952123E9\t6.892659750766351E-4\n3\t387962\t4.0115850428498507E8\t9.671040146375404E-4\n0\t212217\t4.432184030486991E7\t0.004788090894697854\n2\t1053522\t1.731963442166877E8\t0.006082818923024888\n1\t1088884\t4.008368251353978E7\t0.02716526855116638\n"}]},"apps":[],"jobName":"paragraph_1503345355441_489697627","id":"20170809-203309_1972137502","dateCreated":"2017-08-21T19:55:55+0000","status":"FINISHED","progressUpdateIntervalMs":500,"$$hashKey":"object:4126","user":"anonymous","dateFinished":"2017-08-21T22:31:04+0000","dateStarted":"2017-08-21T22:30:57+0000"},{"text":"%angular\r\n\r\n<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.css\" />\r\n<h3>Client-side Integration</h3>\r\n<div id=\"map2\" style=\"height: 600px; width: 100%\"></div>\r\n\r\n<script type=\"text/javascript\">\r\nfunction initMap2() {\r\n    var map2 = L.map('map2').setView([52.5, 13.4], 11);\r\n\r\n    L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {\r\n        attribution: 'Map data &copy; <a href=\"http://openstreetmap.org\">OpenStreetMap</a> contributors',\r\n        maxZoom: 15,\r\n        minZoom: 2\r\n    }).addTo(map2);\r\n\r\n    var geoMarkers = L.layerGroup().addTo(map2);\r\n    var markerIcon = L.icon({\r\n        iconUrl: 'https://openstationmap.org/0.2.0/client/leaflet/images/marker-icon.png',\r\n        iconSize: [24, 32],\r\n    });\r\n\r\n    var el = angular.element($('#map2').parent('.ng-scope'));\r\n    angular.element(el).ready(function() {\r\n        window.pinWatcher = el.scope().compiledScope.$watch('pins', function(pinList, oldValue) {\r\n            geoMarkers.clearLayers();\r\n            angular.forEach(pinList, function(pin) {\r\n                var marker = L.marker([ pin.lat, pin.lon ], {icon: markerIcon})\r\n                  .bindPopup(pin.data)\r\n                  .addTo(geoMarkers);\r\n            });\r\n        })\r\n    });}\r\n\r\nif (window.pinWatcher) {\r\n    // clear existing watcher otherwise we'll have duplicates\r\n    window.pinWatcher();\r\n}\r\n\r\n// ensure we only load the script once, seems to cause issues otherwise\r\nif (window.L) {\r\n    initMap2();\r\n} else {\r\n    console.log('Loading Leaflet library');\r\n    var sc = document.createElement('script');\r\n    sc.type = 'text/javascript';\r\n    sc.src = 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.js';\r\n    sc.onload = initMap2;\r\n    sc.onerror = function(err) { alert(err); }\r\n    document.getElementsByTagName('head')[0].appendChild(sc);\r\n}\r\n</script>","dateUpdated":"2017-08-21T22:27:59+0000","config":{"tableHide":false,"editorSetting":{"language":"text","editOnDblClick":true},"colWidth":8,"editorMode":"ace/mode/undefined","editorHide":false,"results":{},"enabled":true},"settings":{"params":{},"forms":{}},"results":{"code":"SUCCESS","msg":[{"type":"ANGULAR","data":"<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.css\" />\r\n<h3>Client-side Integration</h3>\r\n<div id=\"map2\" style=\"height: 600px; width: 100%\"></div>\r\n\r\n<script type=\"text/javascript\">\r\nfunction initMap2() {\r\n    var map2 = L.map('map2').setView([52.5, 13.4], 11);\r\n\r\n    L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {\r\n        attribution: 'Map data &copy; <a href=\"http://openstreetmap.org\">OpenStreetMap</a> contributors',\r\n        maxZoom: 15,\r\n        minZoom: 2\r\n    }).addTo(map2);\r\n\r\n    var geoMarkers = L.layerGroup().addTo(map2);\r\n    var markerIcon = L.icon({\r\n        iconUrl: 'https://openstationmap.org/0.2.0/client/leaflet/images/marker-icon.png',\r\n        iconSize: [24, 32],\r\n    });\r\n\r\n    var el = angular.element($('#map2').parent('.ng-scope'));\r\n    angular.element(el).ready(function() {\r\n        window.pinWatcher = el.scope().compiledScope.$watch('pins', function(pinList, oldValue) {\r\n            geoMarkers.clearLayers();\r\n            angular.forEach(pinList, function(pin) {\r\n                var marker = L.marker([ pin.lat, pin.lon ], {icon: markerIcon})\r\n                  .bindPopup(pin.data)\r\n                  .addTo(geoMarkers);\r\n            });\r\n        })\r\n    });}\r\n\r\nif (window.pinWatcher) {\r\n    // clear existing watcher otherwise we'll have duplicates\r\n    window.pinWatcher();\r\n}\r\n\r\n// ensure we only load the script once, seems to cause issues otherwise\r\nif (window.L) {\r\n    initMap2();\r\n} else {\r\n    console.log('Loading Leaflet library');\r\n    var sc = document.createElement('script');\r\n    sc.type = 'text/javascript';\r\n    sc.src = 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.js';\r\n    sc.onload = initMap2;\r\n    sc.onerror = function(err) { alert(err); }\r\n    document.getElementsByTagName('head')[0].appendChild(sc);\r\n}\r\n</script>"}]},"apps":[],"jobName":"paragraph_1503345355442_490851874","id":"20170809-021534_2122057818","dateCreated":"2017-08-21T19:55:55+0000","status":"READY","errorMessage":"","progressUpdateIntervalMs":500,"$$hashKey":"object:4127"}],"name":"GDELT Testing","id":"2CQK25JAV","angularObjects":{"2BRWU4WXC:shared_process":[],"2AM1YV5CU:shared_process":[],"2AJXGMUUJ:shared_process":[],"2ANGGHHMQ:shared_process":[],"2AKK3QQXU:shared_process":[]},"config":{"looknfeel":"default","personalizedMode":"false"},"info":{}}
+﻿{
+	"paragraphs": [
+		{
+			"text": "%md\n## Welcome to the GeoWave KMeans GDELT Example (EMR Version).\n##### This is a live note - you can run the code yourself.\n\n### Setup\n<p>\nThe only prerequisite to running this example is increasing your shell interpreter's timeout.<br>\nGo to the <b>Interpreter</b> page, and scroll down to the <b>'sh'</b> section. Click on the <b>'edit'</b> button.<br><br>\nSet the <b>'shell.command.timeout.millisecs'</b> entry to <b>600000</b> (10 minutes).\n</p>\n\n### Execution\n<p>\nThe list of paragraphs below needs to be run sequentially.<br>\nStart at the top, and click the <b>play</b> button in each paragraph, waiting for completion.<br>\nEach paragraph is labeled and commented so you can tell what's happening. A paragraph will be marked<br>\nwith a <b>FINISHED</b> indicator next to the play button when it has run without error.<br><br>\nEnjoy!\n</p>",
+			"dateUpdated": "2017-09-13T08:40:21-0700",
+			"config": {
+				"tableHide": false,
+				"editorSetting": {
+					"language": "markdown",
+					"editOnDblClick": true
+				},
+				"colWidth": 12,
+				"editorMode": "ace/mode/markdown",
+				"editorHide": true,
+				"results": {
+				},
+				"enabled": true
+			},
+			"settings": {
+				"params": {
+				},
+				"forms": {
+				}
+			},
+			"results": {
+				"code": "SUCCESS",
+				"msg": [
+					{
+						"type": "HTML",
+						"data": "<h2>Welcome to the GeoWave KMeans GDELT Example (EMR Version).</h2>\n<h5>This is a live note - you can run the code yourself.</h5>\n<h3>Setup</h3>\n<p>\nThe only prerequisite to running this example is increasing your shell interpreter's timeout.<br>\nGo to the <b>Interpreter</b> page, and scroll down to the <b>'sh'</b> section. Click on the <b>'edit'</b> button.<br><br>\nSet the <b>'shell.command.timeout.millisecs'</b> entry to <b>600000</b> (10 minutes).\n</p>\n<h3>Execution</h3>\n<p>\nThe list of paragraphs below needs to be run sequentially.<br>\nStart at the top, and click the <b>play</b> button in each paragraph, waiting for completion.<br>\nEach paragraph is labeled and commented so you can tell what's happening. A paragraph will be marked<br>\nwith a <b>FINISHED</b> indicator next to the play button when it has run without error.<br><br>\nEnjoy!\n</p>\n"
+					}
+				]
+			},
+			"apps": [
+			],
+			"jobName": "paragraph_1505317221596_1246962899",
+			"id": "20170814-190601_1767735731",
+			"dateCreated": "2017-09-13T08:40:21-0700",
+			"status": "READY",
+			"errorMessage": "",
+			"progressUpdateIntervalMs": 500,
+			"focus": true,
+			"$$hashKey": "object:237"
+		},
+		{
+			"text": "%sh\n# download the GDELT data\ncd /mnt/tmp\nwget s3.amazonaws.com/geowave/latest/scripts/emr/quickstart/geowave-env.sh\nsource geowave-env.sh\nmkdir gdelt\ncd gdelt\nwget http://data.gdeltproject.org/events/md5sums\nfor file in `cat md5sums | cut -d' ' -f3 | grep \"^${TIME_REGEX}\"` ; \\\ndo wget http://data.gdeltproject.org/events/$file ; done\nmd5sum -c md5sums 2>&1 | grep \"^${TIME_REGEX}\"\n",
+			"user": "anonymous",
+			"dateUpdated": "2017-09-13T08:46:09-0700",
+			"config": {
+				"colWidth": 12,
+				"enabled": true,
+				"results": {
+				},
+				"editorSetting": {
+					"language": "sh",
+					"editOnDblClick": false
+				},
+				"editorMode": "ace/mode/sh",
+				"title": true
+			},
+			"settings": {
+				"params": {
+				},
+				"forms": {
+				}
+			},
+			"apps": [
+			],
+			"jobName": "paragraph_1505317263426_-1605318615",
+			"id": "20170913-084103_31433354",
+			"dateCreated": "2017-09-13T08:41:03-0700",
+			"status": "READY",
+			"progressUpdateIntervalMs": 500,
+			"focus": true,
+			"$$hashKey": "object:1084",
+			"title": "Get the Data"
+		},
+		{
+			"title": "Configure GeoWave Datastores and Ingest Data",
+			"text": "%sh\n# configure geowave connection params for hbase stores \"gdelt\" and \"kmeans\"\ngeowave config addstore gdelt --gwNamespace geowave.gdelt -t hbase --zookeeper $HOSTNAME:2181\ngeowave config addstore kmeans --gwNamespace geowave.kmeans -t hbase --zookeeper $HOSTNAME:2181\n\n# configure a spatial index\ngeowave config addindex -t spatial gdelt-spatial --partitionStrategy round_robin --numPartitions $NUM_PARTITIONS\n\n# run the ingest for a 10x10 deg bounding box over Europe\ngeowave ingest localtogw /mnt/tmp/gdelt gdelt gdelt-spatial -f gdelt \\\n--gdelt.cql \"BBOX(geometry, 0, 50, 10, 60)\"",
+			"dateUpdated": "2017-09-13T08:52:38-0700",
+			"config": {
+				"tableHide": false,
+				"editorSetting": {
+					"language": "sh",
+					"editOnDblClick": false
+				},
+				"colWidth": 12,
+				"editorMode": "ace/mode/sh",
+				"editorHide": false,
+				"title": true,
+				"results": {
+				},
+				"enabled": true
+			},
+			"settings": {
+				"params": {
+				},
+				"forms": {
+				}
+			},
+			"apps": [
+			],
+			"jobName": "paragraph_1505317221604_1231572943",
+			"id": "20170809-181755_1512238840",
+			"dateCreated": "2017-09-13T08:40:21-0700",
+			"status": "READY",
+			"errorMessage": "",
+			"progressUpdateIntervalMs": 500,
+			"$$hashKey": "object:238"
+		},
+		{
+			"text": "%sh\n# set up geoserver\ngeowave config geoserver \"$HOSTNAME:8000\"\n\n# add gdelt layer to geoserver\ngeowave gs addlayer gdelt -id gdeltevent\n\n# enable subsampling on the gdelt layer\ncd /mnt/tmp\nwget s3.amazonaws.com/geowave/latest/scripts/emr/quickstart/SubsamplePoints.sld\ngeowave gs addstyle SubsamplePoints -sld /mnt/tmp/SubsamplePoints.sld\ngeowave gs setls gdeltevent --styleName SubsamplePoints\n",
+			"user": "anonymous",
+			"dateUpdated": "2017-09-13T08:50:29-0700",
+			"config": {
+				"tableHide": false,
+				"editorSetting": {
+					"language": "sh",
+					"editOnDblClick": false
+				},
+				"colWidth": 12,
+				"editorMode": "ace/mode/sh",
+				"editorHide": false,
+				"title": true,
+				"results": {
+				},
+				"enabled": true
+			},
+			"settings": {
+				"params": {
+				},
+				"forms": {
+				}
+			},
+			"apps": [
+			],
+			"jobName": "paragraph_1505317698274_-200588345",
+			"id": "20170913-084818_2077241202",
+			"dateCreated": "2017-09-13T08:48:18-0700",
+			"status": "READY",
+			"progressUpdateIntervalMs": 500,
+			"focus": true,
+			"$$hashKey": "object:1159",
+			"title": "Configure GeoServer"
+		},
+		{
+			"title": "Run KMeans on GDELT Subset",
+			"text": "%sh\n# clear out potential old runs\ngeowave remote clear kmeans\n\n# run kmeans\ngeowave analytic kmeansspark gdelt kmeans -f gdeltevent --hulls --cqlFilter \"BBOX(geometry, 0, 50, 10, 60)\" -ch -ht myhulls -ct mycentroids\n",
+			"dateUpdated": "2017-09-13T08:40:21-0700",
+			"config": {
+				"tableHide": false,
+				"editorSetting": {
+					"language": "sh",
+					"editOnDblClick": false
+				},
+				"colWidth": 12,
+				"editorMode": "ace/mode/sh",
+				"editorHide": false,
+				"title": true,
+				"results": {
+				},
+				"enabled": true
+			},
+			"settings": {
+				"params": {
+				},
+				"forms": {
+				}
+			},
+			"apps": [
+			],
+			"jobName": "paragraph_1505317221605_1231188195",
+			"id": "20170809-194032_1817638679",
+			"dateCreated": "2017-09-13T08:40:21-0700",
+			"status": "READY",
+			"errorMessage": "",
+			"progressUpdateIntervalMs": 500,
+			"$$hashKey": "object:239"
+		},
+		{
+			"title": "Add KMeans Results to GeoServer",
+			"text": "%sh\n\n# add the centroids layer\ngeowave gs addlayer kmeans -id mycentroids\ngeowave gs setls mycentroids --styleName point\n\n# add the hulls layer\ngeowave gs addlayer kmeans -id myhulls\ngeowave gs setls myhulls --styleName line",
+			"dateUpdated": "2017-09-13T08:40:21-0700",
+			"config": {
+				"tableHide": false,
+				"editorSetting": {
+					"language": "sh",
+					"editOnDblClick": false
+				},
+				"colWidth": 12,
+				"editorMode": "ace/mode/sh",
+				"title": true,
+				"results": {
+				},
+				"enabled": true
+			},
+			"settings": {
+				"params": {
+				},
+				"forms": {
+				}
+			},
+			"apps": [
+			],
+			"jobName": "paragraph_1505317221606_1232342441",
+			"id": "20170817-030121_1271873891",
+			"dateCreated": "2017-09-13T08:40:21-0700",
+			"status": "READY",
+			"errorMessage": "",
+			"progressUpdateIntervalMs": 500,
+			"$$hashKey": "object:240"
+		},
+		{
+			"text": "%angular\n<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.css\" />\n<h3>GeoWave Leaflet Map</h3>\n<div id=\"map\" style=\"height: 600px; width: 100%\"></div>\n\n<script type=\"text/javascript\">\n\n\nfunction initMap() {\n    var map = L.map('map').setView([50.00, 10.00], 5);\n    \n    var host='ec2-52-55-84-142.compute-1.amazonaws.com';\n    mapLink = '<a href=\"http://www.esri.com/\">Esri</a>';\n    wholink = 'i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community';\n\n    var basemaps = {\n        OSM: L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {\n            attribution: 'Map data &copy; <a href=\"http://openstreetmap.org\">OpenStreetMap</a> contributors',\n            maxZoom: 15,\n            minZoom: 2\n        }),\n        Satellite:L.tileLayer(\n            'http://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {\n            attribution: '&copy; '+mapLink+', '+wholink,\n            maxZoom: 18,\n        }),\n        LANDSAT: L.tileLayer.wms('http://'+host+':8000/geoserver/geowave/wms?', {\n            layers: 'geowave:germany_mosaic',\n            format: 'image/jpeg'\n        })\n    };\n    \n    var overlays = {\n        GDELT:L.tileLayer.wms('http://'+host+':8000/geoserver/geowave/wms?', {\n            layers: 'geowave:gdeltevent',\n            format: 'image/png',\n            transparent: true\n        }),\n        \n        KMeansCentroids:L.tileLayer.wms('http://'+host+':8000/geoserver/geowave/wms?', {\n            layers: 'geowave:mycentroids',\n            format: 'image/png',\n            transparent: true\n        }),\n        \n        KMeansHulls:L.tileLayer.wms('http://'+host+':8000/geoserver/geowave/wms?', {\n            layers: 'geowave:myhulls',\n            format: 'image/png',\n            transparent: true\n        })\n    };\n\n    L.control.layers(basemaps, overlays).addTo(map);\n    \n    basemaps.OSM.addTo(map);\n}\n\n// ensure we only load the script once, seems to cause issues otherwise\nif (window.L) {\n    initMap();\n} else {\n    console.log('Loading Leaflet library');\n    var sc = document.createElement('script');\n    sc.type = 'text/javascript';\n    sc.src = 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.js';\n    sc.onload = initMap;\n    sc.onerror = function(err) { alert(err); }\n    document.getElementsByTagName('head')[0].appendChild(sc);\n}\n</script>\n",
+			"dateUpdated": "2017-09-13T08:40:21-0700",
+			"config": {
+				"tableHide": false,
+				"editorSetting": {
+					"language": "scala",
+					"editOnDblClick": true
+				},
+				"colWidth": 12,
+				"editorMode": "ace/mode/undefined",
+				"editorHide": true,
+				"results": {
+				},
+				"enabled": true
+			},
+			"settings": {
+				"params": {
+				},
+				"forms": {
+				}
+			},
+			"results": {
+				"code": "SUCCESS",
+				"msg": [
+					{
+						"type": "ANGULAR",
+						"data": "<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.css\" />\n<h3>GeoWave Leaflet Map</h3>\n<div id=\"map\" style=\"height: 600px; width: 100%\"></div>\n\n<script type=\"text/javascript\">\n\n\nfunction initMap() {\n    var map = L.map('map').setView([50.00, 10.00], 5);\n    \n    var host='ec2-52-55-84-142.compute-1.amazonaws.com';\n    mapLink = '<a href=\"http://www.esri.com/\">Esri</a>';\n    wholink = 'i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community';\n\n    var basemaps = {\n        OSM: L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {\n            attribution: 'Map data &copy; <a href=\"http://openstreetmap.org\">OpenStreetMap</a> contributors',\n            maxZoom: 15,\n            minZoom: 2\n        }),\n        Satellite:L.tileLayer(\n            'http://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {\n            attribution: '&copy; '+mapLink+', '+wholink,\n            maxZoom: 18,\n        }),\n        LANDSAT: L.tileLayer.wms('http://'+host+':8000/geoserver/geowave/wms?', {\n            layers: 'geowave:germany_mosaic',\n            format: 'image/jpeg'\n        })\n    };\n    \n    var overlays = {\n        GDELT:L.tileLayer.wms('http://'+host+':8000/geoserver/geowave/wms?', {\n            layers: 'geowave:gdeltevent',\n            format: 'image/png',\n            transparent: true\n        }),\n        \n        KMeansCentroids:L.tileLayer.wms('http://'+host+':8000/geoserver/geowave/wms?', {\n            layers: 'geowave:mycentroids',\n            format: 'image/png',\n            transparent: true\n        }),\n        \n        KMeansHulls:L.tileLayer.wms('http://'+host+':8000/geoserver/geowave/wms?', {\n            layers: 'geowave:myhulls',\n            format: 'image/png',\n            transparent: true\n        })\n    };\n\n    L.control.layers(basemaps, overlays).addTo(map);\n    \n    basemaps.OSM.addTo(map);\n}\n\n// ensure we only load the script once, seems to cause issues otherwise\nif (window.L) {\n    initMap();\n} else {\n    console.log('Loading Leaflet library');\n    var sc = document.createElement('script');\n    sc.type = 'text/javascript';\n    sc.src = 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.js';\n    sc.onload = initMap;\n    sc.onerror = function(err) { alert(err); }\n    document.getElementsByTagName('head')[0].appendChild(sc);\n}\n</script>"
+					}
+				]
+			},
+			"apps": [
+			],
+			"jobName": "paragraph_1505317221607_1231957692",
+			"id": "20170817-030613_874309201",
+			"dateCreated": "2017-09-13T08:40:21-0700",
+			"status": "READY",
+			"errorMessage": "",
+			"progressUpdateIntervalMs": 500,
+			"$$hashKey": "object:241"
+		},
+		{
+			"title": "Export KMeans Hulls to CSV",
+			"text": "%sh\n# Set up the temp folder\ncd /mnt/tmp\nrm -rf kmeans\nmkdir kmeans\n\n# Query kmeans centroids and write to local temp file\ngeowave analytic sql \"select * from kmeans|myhulls\" --csv /mnt/tmp/kmeans\n\n# Move the csv output to hdfs\nmv kmeans/part*.csv mykmeans.csv\nhdfs dfs -rm /user/zeppelin/mykmeans.csv\nhdfs dfs -put mykmeans.csv /user/zeppelin/mykmeans.csv",
+			"dateUpdated": "2017-09-13T08:40:21-0700",
+			"config": {
+				"tableHide": false,
+				"editorSetting": {
+					"language": "sh",
+					"editOnDblClick": false
+				},
+				"colWidth": 12,
+				"editorMode": "ace/mode/sh",
+				"editorHide": false,
+				"title": true,
+				"results": {
+				},
+				"enabled": true
+			},
+			"settings": {
+				"params": {
+				},
+				"forms": {
+				}
+			},
+			"apps": [
+			],
+			"jobName": "paragraph_1505317221608_1230033948",
+			"id": "20170809-201803_119430460",
+			"dateCreated": "2017-09-13T08:40:21-0700",
+			"status": "READY",
+			"errorMessage": "",
+			"progressUpdateIntervalMs": 500,
+			"$$hashKey": "object:242"
+		},
+		{
+			"title": "Load KMeans Hull CSV into DataFrame",
+			"text": "// load centroid data from hdfs\nval kmeansText = sc.textFile(\"/user/zeppelin/mykmeans.csv\")\n\ncase class KMeansRow(index: Int, count: Int, area: Double, density: Double)\n\n// split each line, filter out header (starts with \"geom\"), and map it into data class\nval kmeansData = kmeansText.map(s=>s.split(\",(?=([^\\\"]*\\\"[^\\\"]*\\\")*[^\\\"]*$)\")).filter(s=>s(0)!=\"geom\").map(\n    s=>KMeansRow(s(1).toInt, s(2).toInt, s(3).toDouble, s(4).toDouble)\n)\n\n// send the results to the front end (Leaflet map)\nz.angularBind(\"pins\", kmeansData.collect())\n\n// register a view for SQL queries\nkmeansData.toDF().registerTempTable(\"kmeans\")\n",
+			"dateUpdated": "2017-09-13T08:40:21-0700",
+			"config": {
+				"tableHide": false,
+				"editorSetting": {
+					"language": "scala",
+					"editOnDblClick": false
+				},
+				"colWidth": 12,
+				"editorMode": "ace/mode/scala",
+				"editorHide": false,
+				"title": true,
+				"results": {
+				},
+				"enabled": true
+			},
+			"settings": {
+				"params": {
+				},
+				"forms": {
+				}
+			},
+			"apps": [
+			],
+			"jobName": "paragraph_1505317221609_1229649199",
+			"id": "20170814-174640_830156690",
+			"dateCreated": "2017-09-13T08:40:21-0700",
+			"status": "READY",
+			"errorMessage": "",
+			"progressUpdateIntervalMs": 500,
+			"$$hashKey": "object:243"
+		},
+		{
+			"title": "Display the KMeans Hulls Table",
+			"text": "%sql\nselect * from kmeans order by density",
+			"dateUpdated": "2017-09-13T08:40:21-0700",
+			"config": {
+				"editorSetting": {
+					"language": "sql",
+					"editOnDblClick": false
+				},
+				"colWidth": 8,
+				"editorMode": "ace/mode/sql",
+				"editorHide": false,
+				"title": true,
+				"results": {
+					"0": {
+						"graph": {
+							"mode": "table",
+							"height": 300,
+							"optionOpen": false
+						},
+						"helium": {
+						}
+					}
+				},
+				"enabled": true
+			},
+			"settings": {
+				"params": {
+				},
+				"forms": {
+				}
+			},
+			"results": {
+				"code": "SUCCESS",
+				"msg": [
+					{
+						"type": "TABLE",
+						"data": "index\tcount\tarea\tdensity\n4\t115539\t2.0908055080757553E11\t5.526052019364286E-7\n5\t538828\t8.933931988110149E10\t6.0312525405063186E-6\n7\t1830244\t2.2347503902920425E10\t8.189925854586469E-5\n6\t749083\t1.0867836612952123E9\t6.892659750766351E-4\n3\t387962\t4.0115850428498507E8\t9.671040146375404E-4\n0\t212217\t4.432184030486991E7\t0.004788090894697854\n2\t1053522\t1.731963442166877E8\t0.006082818923024888\n1\t1088884\t4.008368251353978E7\t0.02716526855116638\n"
+					}
+				]
+			},
+			"apps": [
+			],
+			"jobName": "paragraph_1505317221610_1230803446",
+			"id": "20170809-203309_1972137502",
+			"dateCreated": "2017-09-13T08:40:21-0700",
+			"status": "READY",
+			"errorMessage": "",
+			"progressUpdateIntervalMs": 500,
+			"$$hashKey": "object:244"
+		},
+		{
+			"text": "%angular\r\n\r\n<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.css\" />\r\n<h3>Client-side Integration</h3>\r\n<div id=\"map2\" style=\"height: 600px; width: 100%\"></div>\r\n\r\n<script type=\"text/javascript\">\r\nfunction initMap2() {\r\n    var map2 = L.map('map2').setView([52.5, 13.4], 11);\r\n\r\n    L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {\r\n        attribution: 'Map data &copy; <a href=\"http://openstreetmap.org\">OpenStreetMap</a> contributors',\r\n        maxZoom: 15,\r\n        minZoom: 2\r\n    }).addTo(map2);\r\n\r\n    var geoMarkers = L.layerGroup().addTo(map2);\r\n    var markerIcon = L.icon({\r\n        iconUrl: 'https://openstationmap.org/0.2.0/client/leaflet/images/marker-icon.png',\r\n        iconSize: [24, 32],\r\n    });\r\n\r\n    var el = angular.element($('#map2').parent('.ng-scope'));\r\n    angular.element(el).ready(function() {\r\n        window.pinWatcher = el.scope().compiledScope.$watch('pins', function(pinList, oldValue) {\r\n            geoMarkers.clearLayers();\r\n            angular.forEach(pinList, function(pin) {\r\n                var marker = L.marker([ pin.lat, pin.lon ], {icon: markerIcon})\r\n                  .bindPopup(pin.data)\r\n                  .addTo(geoMarkers);\r\n            });\r\n        })\r\n    });}\r\n\r\nif (window.pinWatcher) {\r\n    // clear existing watcher otherwise we'll have duplicates\r\n    window.pinWatcher();\r\n}\r\n\r\n// ensure we only load the script once, seems to cause issues otherwise\r\nif (window.L) {\r\n    initMap2();\r\n} else {\r\n    console.log('Loading Leaflet library');\r\n    var sc = document.createElement('script');\r\n    sc.type = 'text/javascript';\r\n    sc.src = 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.js';\r\n    sc.onload = initMap2;\r\n    sc.onerror = function(err) { alert(err); }\r\n    document.getElementsByTagName('head')[0].appendChild(sc);\r\n}\r\n</script>",
+			"dateUpdated": "2017-09-13T08:40:21-0700",
+			"config": {
+				"tableHide": false,
+				"editorSetting": {
+					"language": "text",
+					"editOnDblClick": true
+				},
+				"colWidth": 8,
+				"editorMode": "ace/mode/undefined",
+				"editorHide": false,
+				"results": {
+				},
+				"enabled": true
+			},
+			"settings": {
+				"params": {
+				},
+				"forms": {
+				}
+			},
+			"results": {
+				"code": "SUCCESS",
+				"msg": [
+					{
+						"type": "ANGULAR",
+						"data": "<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.css\" />\r\n<h3>Client-side Integration</h3>\r\n<div id=\"map2\" style=\"height: 600px; width: 100%\"></div>\r\n\r\n<script type=\"text/javascript\">\r\nfunction initMap2() {\r\n    var map2 = L.map('map2').setView([52.5, 13.4], 11);\r\n\r\n    L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {\r\n        attribution: 'Map data &copy; <a href=\"http://openstreetmap.org\">OpenStreetMap</a> contributors',\r\n        maxZoom: 15,\r\n        minZoom: 2\r\n    }).addTo(map2);\r\n\r\n    var geoMarkers = L.layerGroup().addTo(map2);\r\n    var markerIcon = L.icon({\r\n        iconUrl: 'https://openstationmap.org/0.2.0/client/leaflet/images/marker-icon.png',\r\n        iconSize: [24, 32],\r\n    });\r\n\r\n    var el = angular.element($('#map2').parent('.ng-scope'));\r\n    angular.element(el).ready(function() {\r\n        window.pinWatcher = el.scope().compiledScope.$watch('pins', function(pinList, oldValue) {\r\n            geoMarkers.clearLayers();\r\n            angular.forEach(pinList, function(pin) {\r\n                var marker = L.marker([ pin.lat, pin.lon ], {icon: markerIcon})\r\n                  .bindPopup(pin.data)\r\n                  .addTo(geoMarkers);\r\n            });\r\n        })\r\n    });}\r\n\r\nif (window.pinWatcher) {\r\n    // clear existing watcher otherwise we'll have duplicates\r\n    window.pinWatcher();\r\n}\r\n\r\n// ensure we only load the script once, seems to cause issues otherwise\r\nif (window.L) {\r\n    initMap2();\r\n} else {\r\n    console.log('Loading Leaflet library');\r\n    var sc = document.createElement('script');\r\n    sc.type = 'text/javascript';\r\n    sc.src = 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.js';\r\n    sc.onload = initMap2;\r\n    sc.onerror = function(err) { alert(err); }\r\n    document.getElementsByTagName('head')[0].appendChild(sc);\r\n}\r\n</script>"
+					}
+				]
+			},
+			"apps": [
+			],
+			"jobName": "paragraph_1505317221611_1230418697",
+			"id": "20170809-021534_2122057818",
+			"dateCreated": "2017-09-13T08:40:21-0700",
+			"status": "READY",
+			"errorMessage": "",
+			"progressUpdateIntervalMs": 500,
+			"$$hashKey": "object:245"
+		}
+	],
+	"name": "GDELT Testing",
+	"id": "2CS2NWQ2Z",
+	"angularObjects": {
+		"2CQ45EQN3:shared_process": [
+		],
+		"2CRMR95VM:shared_process": [
+		],
+		"2CR7HU4K5:shared_process": [
+		],
+		"2CNZDBXB1:shared_process": [
+		],
+		"2CSSPJY6E:shared_process": [
+		],
+		"2CR9SXZU2:shared_process": [
+		],
+		"2CP794URS:shared_process": [
+		],
+		"2CS1T6Z8H:shared_process": [
+		],
+		"2CRRSU11A:shared_process": [
+		],
+		"2CQ6DYKSD:shared_process": [
+		],
+		"2CQUHQ6N9:shared_process": [
+		],
+		"2CSM6GRR3:shared_process": [
+		],
+		"2CRS36YKB:shared_process": [
+		],
+		"2CQDNDSDA:shared_process": [
+		],
+		"2CS7FBNVX:shared_process": [
+		],
+		"2CP5MBF4A:shared_process": [
+		],
+		"2CQQKN5PH:shared_process": [
+		],
+		"2CQDTRBTZ:shared_process": [
+		],
+		"2CR7ANRVS:shared_process": [
+		]
+	},
+	"config": {
+		"looknfeel": "default",
+		"personalizedMode": "false"
+	},
+	"info": {
+	}
+}

--- a/examples/data/notebooks/zeppelin/GeoWave-GPX-Demo.json
+++ b/examples/data/notebooks/zeppelin/GeoWave-GPX-Demo.json
@@ -1,8 +1,8 @@
 ﻿{
 	"paragraphs": [
 		{
-			"text": "%md\n## Welcome to the GeoWave KMeans GPX Example (EMR Version).\n##### This is a live note - you can run the code yourself.\n\n### Setup\n<p>\nThe only prerequisite to running this example is increasing your shell interpreter's timeout.<br>\nGo to the <b>Interpreter</b> page, and scroll down to the <b>'sh'</b> section. Click on the <b>'edit'</b> button.<br><br>\nSet the <b>'shell.command.timeout.millisecs'</b> entry to <b>600000</b> (10 minutes).\n</p>\n\n### Execution\n<p>\nThe list of paragraphs below needs to be run sequentially.<br>\nStart at the top, and click the <b>play</b> button in each paragraph, waiting for completion.<br>\nEach paragraph is labeled and commented so you can tell what's happening. A paragraph will be marked<br>\nwith a <b>FINISHED</b> indicator next to the play button when it has run without error.<br><br>\nEnjoy!\n</p>",
-			"dateUpdated": "2017-08-17T14:08:07+0000",
+			"text": "%md\n## Welcome to the GeoWave GPX KMeans Example (EMR Version).\n##### This is a live note - you can run the code yourself.\n\n### Setup\n<p>\nThe only prerequisite to running this example is increasing your shell interpreter's timeout.<br>\nGo to the <b>Interpreter</b> page, and scroll down to the <b>'sh'</b> section. Click on the <b>'edit'</b> button.<br><br>\nSet the <b>'shell.command.timeout.millisecs'</b> entry to <b>600000</b> (10 minutes).\n</p>\n\n### Execution\n<p>\nThe list of paragraphs below needs to be run sequentially.<br>\nStart at the top, and click the <b>play</b> button in each paragraph, waiting for completion.<br>\nEach paragraph is labeled and commented so you can tell what's happening. A paragraph will be marked<br>\nwith a <b>FINISHED</b> indicator next to the play button when it has run without error.<br><br>\nEnjoy!\n</p>",
+			"dateUpdated": "2017-09-14T11:08:44-0700",
 			"config": {
 				"tableHide": false,
 				"editorSetting": {
@@ -27,25 +27,27 @@
 				"msg": [
 					{
 						"type": "HTML",
-						"data": "<h2>Welcome to the GeoWave KMeans GPX Example (EMR Version).</h2>\n<h5>This is a live note - you can run the code yourself.</h5>\n<h3>Setup</h3>\n<p>\nThe only prerequisite to running this example is increasing your shell interpreter's timeout.<br>\nGo to the <b>Interpreter</b> page, and scroll down to the <b>'sh'</b> section. Click on the <b>'edit'</b> button.<br><br>\nSet the <b>'shell.command.timeout.millisecs'</b> entry to <b>600000</b> (10 minutes).\n</p>\n<h3>Execution</h3>\n<p>\nThe list of paragraphs below needs to be run sequentially.<br>\nStart at the top, and click the <b>play</b> button in each paragraph, waiting for completion.<br>\nEach paragraph is labeled and commented so you can tell what's happening. A paragraph will be marked<br>\nwith a <b>FINISHED</b> indicator next to the play button when it has run without error.<br><br>\nEnjoy!\n</p>\n"
+						"data": "<div class=\"markdown-body\">\n<h2>Welcome to the GeoWave GPX KMeans Example (EMR Version).</h2>\n<h5>This is a live note - you can run the code yourself.</h5>\n<h3>Setup</h3>\n<p>\nThe only prerequisite to running this example is increasing your shell interpreter's timeout.<br>\nGo to the <b>Interpreter</b> page, and scroll down to the <b>'sh'</b> section. Click on the <b>'edit'</b> button.<br><br>\nSet the <b>'shell.command.timeout.millisecs'</b> entry to <b>600000</b> (10 minutes).\n</p>\n<h3>Execution</h3>\n<p>\nThe list of paragraphs below needs to be run sequentially.<br>\nStart at the top, and click the <b>play</b> button in each paragraph, waiting for completion.<br>\nEach paragraph is labeled and commented so you can tell what's happening. A paragraph will be marked<br>\nwith a <b>FINISHED</b> indicator next to the play button when it has run without error.<br><br>\nEnjoy!\n</p>\n</div>"
 					}
 				]
 			},
 			"apps": [
 			],
-			"jobName": "paragraph_1502978887586_-1736619222",
+			"jobName": "paragraph_1505412249530_-577076375",
 			"id": "20170814-190601_1767735731",
-			"dateCreated": "2017-08-17T14:08:07+0000",
-			"status": "READY",
-			"errorMessage": "",
+			"dateCreated": "2017-09-14T11:04:09-0700",
+			"status": "FINISHED",
 			"progressUpdateIntervalMs": 500,
 			"focus": true,
-			"$$hashKey": "object:1781"
+			"$$hashKey": "object:4326",
+			"user": "anonymous",
+			"dateFinished": "2017-09-14T11:08:46-0700",
+			"dateStarted": "2017-09-14T11:08:45-0700"
 		},
 		{
 			"title": "Import GPX Data",
 			"text": "%sh\ns3-dist-cp --src=s3://geowave-0.9.5-accumulo/gpx --dest=hdfs://$HOSTNAME:8020/tmp/\n\n/opt/accumulo/bin/accumulo shell -u root -p secret -e \"importtable geowave.germany_gpx_SPATIAL_IDX /tmp/spatial\"\n/opt/accumulo/bin/accumulo shell -u root -p secret -e \"importtable geowave.germany_gpx_GEOWAVE_METADATA /tmp/metadata\"",
-			"dateUpdated": "2017-08-17T14:15:40+0000",
+			"dateUpdated": "2017-09-14T11:04:09-0700",
 			"config": {
 				"tableHide": true,
 				"editorSetting": {
@@ -81,20 +83,18 @@
 			},
 			"apps": [
 			],
-			"jobName": "paragraph_1502978887589_-1739312464",
+			"jobName": "paragraph_1505412249532_-579384868",
 			"id": "20170815-204020_1185378225",
-			"dateCreated": "2017-08-17T14:08:07+0000",
-			"status": "FINISHED",
+			"dateCreated": "2017-09-14T11:04:09-0700",
+			"status": "READY",
+			"errorMessage": "",
 			"progressUpdateIntervalMs": 500,
-			"$$hashKey": "object:1782",
-			"user": "anonymous",
-			"dateFinished": "2017-08-17T14:14:19+0000",
-			"dateStarted": "2017-08-17T14:13:04+0000"
+			"$$hashKey": "object:4327"
 		},
 		{
 			"title": "Configure GeoWave",
 			"text": "%sh\n# clear out potential old runs\ngeowave config rmstore kmeans_hbase\ngeowave config rmstore germany_gpx_accumulo\n\n# configure geowave connection params for name stores \"germany_gpx_accumulo\" and \"kmeans_hbase\"\ngeowave config addstore germany_gpx_accumulo --gwNamespace geowave.germany_gpx -t accumulo --zookeeper $HOSTNAME:2181 --instance accumulo --user root --password secret\ngeowave config addstore kmeans_hbase --gwNamespace geowave.kmeans -t hbase --zookeeper $HOSTNAME:2181\n\n# set up geoserver\ngeowave config geoserver \"$HOSTNAME:8000\"\n\n# add gpx layer\ngeowave gs addlayer germany_gpx_accumulo -id gpxpoint\nwget s3.amazonaws.com/geowave/latest/scripts/emr/quickstart/SubsamplePoints.sld\ngeowave gs addstyle SubsamplePoints -sld SubsamplePoints.sld\ngeowave gs setls gpxpoint --styleName SubsamplePoints\n\n# add landsat layer\ngeowave config rmstore imagery\ngeowave config addstore imagery -t hbase -z $HOSTNAME:2181 --gwNamespace geowave.landsat_raster\ngeowave gs addlayer imagery -id germany_mosaic\n",
-			"dateUpdated": "2017-08-17T14:16:16+0000",
+			"dateUpdated": "2017-09-14T11:04:09-0700",
 			"config": {
 				"tableHide": true,
 				"editorSetting": {
@@ -126,20 +126,18 @@
 			},
 			"apps": [
 			],
-			"jobName": "paragraph_1502978887590_-1738158217",
+			"jobName": "paragraph_1505412249533_-579769617",
 			"id": "20170809-181755_1512238840",
-			"dateCreated": "2017-08-17T14:08:07+0000",
-			"status": "FINISHED",
+			"dateCreated": "2017-09-14T11:04:09-0700",
+			"status": "READY",
+			"errorMessage": "",
 			"progressUpdateIntervalMs": 500,
-			"$$hashKey": "object:1783",
-			"user": "anonymous",
-			"dateFinished": "2017-08-17T14:16:06+0000",
-			"dateStarted": "2017-08-17T14:15:48+0000"
+			"$$hashKey": "object:4328"
 		},
 		{
 			"title": "Run KMeans on GPX Subset",
-			"text": "%sh\n# clear out potential old runs\ngeowave remote clear kmeans_hbase\n\n# run kmeans\ngeowave analytic kmeansspark germany_gpx_accumulo kmeans_hbase -k 8 -f gpxpoint --hulls --bbox \"13.3 52.45 13.5 52.55\"\n",
-			"dateUpdated": "2017-08-17T14:17:42+0000",
+			"text": "%sh\n# clear out potential old runs\ngeowave remote clear kmeans_hbase\n\n# run kmeans\ngeowave analytic kmeansspark germany_gpx_accumulo kmeans_hbase -k 8 -f gpxpoint --hulls --cqlFilter \"BBOX(geometry, 13.3, 52.45, 13.5, 52.55)\"\n",
+			"dateUpdated": "2017-09-14T11:05:51-0700",
 			"config": {
 				"tableHide": true,
 				"editorSetting": {
@@ -171,20 +169,18 @@
 			},
 			"apps": [
 			],
-			"jobName": "paragraph_1502978887590_-1738158217",
+			"jobName": "paragraph_1505412249534_-578615370",
 			"id": "20170809-194032_1817638679",
-			"dateCreated": "2017-08-17T14:08:07+0000",
-			"status": "FINISHED",
+			"dateCreated": "2017-09-14T11:04:09-0700",
+			"status": "READY",
+			"errorMessage": "",
 			"progressUpdateIntervalMs": 500,
-			"$$hashKey": "object:1784",
-			"user": "anonymous",
-			"dateFinished": "2017-08-17T14:17:32+0000",
-			"dateStarted": "2017-08-17T14:16:27+0000"
+			"$$hashKey": "object:4329"
 		},
 		{
 			"title": "Add KMeans Results to GeoServer",
 			"text": "%sh\n\n# add the centroids layer\ngeowave gs addlayer kmeans_hbase -id kmeans-centroids\ngeowave gs setls kmeans-centroids --styleName point\n\n# add the hulls layer\ngeowave gs addlayer kmeans_hbase -id kmeans-hulls\ngeowave gs setls kmeans-hulls --styleName line",
-			"dateUpdated": "2017-08-17T14:17:46+0000",
+			"dateUpdated": "2017-09-14T11:04:09-0700",
 			"config": {
 				"tableHide": true,
 				"editorSetting": {
@@ -215,19 +211,17 @@
 			},
 			"apps": [
 			],
-			"jobName": "paragraph_1502978887591_-1738542966",
+			"jobName": "paragraph_1505412249535_-579000119",
 			"id": "20170817-030121_1271873891",
-			"dateCreated": "2017-08-17T14:08:07+0000",
-			"status": "FINISHED",
+			"dateCreated": "2017-09-14T11:04:09-0700",
+			"status": "READY",
+			"errorMessage": "",
 			"progressUpdateIntervalMs": 500,
-			"$$hashKey": "object:1785",
-			"user": "anonymous",
-			"dateFinished": "2017-08-17T14:17:52+0000",
-			"dateStarted": "2017-08-17T14:17:46+0000"
+			"$$hashKey": "object:4330"
 		},
 		{
 			"text": "%angular\n<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.css\" />\n<h3>GeoWave Leaflet Map</h3>\n<div id=\"map\" style=\"height: 600px; width: 100%\"></div>\n\n<script type=\"text/javascript\">\n\n\nfunction initMap() {\n    var map = L.map('map').setView([50.00, 10.00], 5);\n    \n    var host='localhost';\n    mapLink = '<a href=\"http://www.esri.com/\">Esri</a>';\n    wholink = 'i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community';\n\n    var basemaps = {\n        OSM: L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {\n            attribution: 'Map data &copy; <a href=\"http://openstreetmap.org\">OpenStreetMap</a> contributors',\n            maxZoom: 15,\n            minZoom: 2\n        }),\n        Satellite:L.tileLayer(\n            'http://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {\n            attribution: '&copy; '+mapLink+', '+wholink,\n            maxZoom: 18,\n        }),\n        LANDSAT: L.tileLayer.wms('http://'+host+':8000/geoserver/geowave/wms?', {\n            layers: 'geowave:germany_mosaic',\n            format: 'image/jpeg'\n        })\n    };\n    \n    var overlays = {\n        GPX:L.tileLayer.wms('http://'+host+':8000/geoserver/geowave/wms?', {\n            layers: 'geowave:gpxpoint',\n            format: 'image/png',\n            transparent: true\n        }),\n        \n        KMeansCentroids:L.tileLayer.wms('http://'+host+':8000/geoserver/geowave/wms?', {\n            layers: 'geowave:kmeans-centroids',\n            format: 'image/png',\n            transparent: true\n        }),\n        \n        KMeansHulls:L.tileLayer.wms('http://'+host+':8000/geoserver/geowave/wms?', {\n            layers: 'geowave:kmeans-hulls',\n            format: 'image/png',\n            transparent: true\n        })\n    };\n\n    L.control.layers(basemaps, overlays).addTo(map);\n    \n    basemaps.OSM.addTo(map);\n}\n\n// ensure we only load the script once, seems to cause issues otherwise\nif (window.L) {\n    initMap();\n} else {\n    console.log('Loading Leaflet library');\n    var sc = document.createElement('script');\n    sc.type = 'text/javascript';\n    sc.src = 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.js';\n    sc.onload = initMap;\n    sc.onerror = function(err) { alert(err); }\n    document.getElementsByTagName('head')[0].appendChild(sc);\n}\n</script>\n",
-			"dateUpdated": "2017-08-17T14:25:09+0000",
+			"dateUpdated": "2017-09-14T11:04:09-0700",
 			"config": {
 				"tableHide": false,
 				"editorSetting": {
@@ -258,20 +252,18 @@
 			},
 			"apps": [
 			],
-			"jobName": "paragraph_1502978887595_-1740081962",
+			"jobName": "paragraph_1505412249535_-579000119",
 			"id": "20170817-030613_874309201",
-			"dateCreated": "2017-08-17T14:08:07+0000",
-			"status": "FINISHED",
+			"dateCreated": "2017-09-14T11:04:09-0700",
+			"status": "READY",
+			"errorMessage": "",
 			"progressUpdateIntervalMs": 500,
-			"$$hashKey": "object:1786",
-			"user": "anonymous",
-			"dateFinished": "2017-08-17T14:25:09+0000",
-			"dateStarted": "2017-08-17T14:25:09+0000"
+			"$$hashKey": "object:4331"
 		},
 		{
 			"title": "Export KMeans Centroids to CSV",
 			"text": "%sh\n# Set up the temp folder\ncd /mnt/tmp\nrm -rf kmeans\nmkdir kmeans\n\n# Query kmeans centroids and write to local temp file\ngeowave analytic sql \"select * from kmeans_hbase|kmeans-centroids\" --csv /mnt/tmp/kmeans\n\n# Move the csv output to hdfs\nmv kmeans/part*.csv kmeans-centroids.csv\nhdfs dfs -rm /user/zeppelin/kmeans-centroids.csv\nhdfs dfs -put kmeans-centroids.csv /user/zeppelin/kmeans-centroids.csv",
-			"dateUpdated": "2017-08-17T14:21:26+0000",
+			"dateUpdated": "2017-09-14T11:04:09-0700",
 			"config": {
 				"tableHide": true,
 				"editorSetting": {
@@ -303,20 +295,18 @@
 			},
 			"apps": [
 			],
-			"jobName": "paragraph_1502978887596_-1742005706",
+			"jobName": "paragraph_1505412249536_-593235829",
 			"id": "20170809-201803_119430460",
-			"dateCreated": "2017-08-17T14:08:07+0000",
-			"status": "FINISHED",
+			"dateCreated": "2017-09-14T11:04:09-0700",
+			"status": "READY",
+			"errorMessage": "",
 			"progressUpdateIntervalMs": 500,
-			"$$hashKey": "object:1787",
-			"user": "anonymous",
-			"dateFinished": "2017-08-17T14:21:23+0000",
-			"dateStarted": "2017-08-17T14:21:14+0000"
+			"$$hashKey": "object:4332"
 		},
 		{
 			"title": "Load KMeans Centroid CSV into DataFrame",
 			"text": "// load centroid data from hdfs\nval kmeansText = sc.textFile(\"/user/zeppelin/kmeans-centroids.csv\")\n\ncase class KMeansRow(lat: Double, lon: Double, data : String)\n\ndef parseLat (wkt: String) : Double = {\n   val latStart = wkt.lastIndexOf(\" \") + 1\n   val latStop = wkt.lastIndexOf(\")\")\n   val latStr = wkt.substring(latStart, latStop)\n   return latStr.toDouble\n}\n\ndef parseLon (wkt: String) : Double = {\n   val lonStart = wkt.indexOf(\"(\") + 1\n   val lonStop = wkt.indexOf(\" \", lonStart)\n   val lonStr = wkt.substring(lonStart, lonStop)\n   return lonStr.toDouble\n}\n\n// split each line, filter out header (starts with \"geom\"), and map it into data class\nval kmeansData = kmeansText.map(s=>s.split(\",\")).filter(s=>s(0)!=\"geom\").map(\n    s=>KMeansRow(parseLat(s(0)), parseLon(s(0)), s(1))\n)\n\n// send the results to the front end (Leaflet map)\nz.angularBind(\"pins\", kmeansData.collect())\n\n// register a view for SQL queries\nkmeansData.toDF().registerTempTable(\"kmeans\")\n",
-			"dateUpdated": "2017-08-17T14:22:10+0000",
+			"dateUpdated": "2017-09-14T11:04:09-0700",
 			"config": {
 				"tableHide": true,
 				"editorSetting": {
@@ -348,20 +338,18 @@
 			},
 			"apps": [
 			],
-			"jobName": "paragraph_1502978887596_-1742005706",
+			"jobName": "paragraph_1505412249536_-593235829",
 			"id": "20170814-174640_830156690",
-			"dateCreated": "2017-08-17T14:08:07+0000",
-			"status": "FINISHED",
+			"dateCreated": "2017-09-14T11:04:09-0700",
+			"status": "READY",
+			"errorMessage": "",
 			"progressUpdateIntervalMs": 500,
-			"$$hashKey": "object:1788",
-			"user": "anonymous",
-			"dateFinished": "2017-08-17T14:22:06+0000",
-			"dateStarted": "2017-08-17T14:21:33+0000"
+			"$$hashKey": "object:4333"
 		},
 		{
 			"title": "Display the KMeans Centroids Table",
 			"text": "%sql\nselect lat as Latitude, lon as Longitude from kmeans",
-			"dateUpdated": "2017-08-17T14:22:17+0000",
+			"dateUpdated": "2017-09-14T11:04:09-0700",
 			"config": {
 				"editorSetting": {
 					"language": "sql",
@@ -401,19 +389,17 @@
 			},
 			"apps": [
 			],
-			"jobName": "paragraph_1502978887597_-1742390455",
+			"jobName": "paragraph_1505412249537_-593620577",
 			"id": "20170809-203309_1972137502",
-			"dateCreated": "2017-08-17T14:08:07+0000",
-			"status": "FINISHED",
+			"dateCreated": "2017-09-14T11:04:09-0700",
+			"status": "READY",
+			"errorMessage": "",
 			"progressUpdateIntervalMs": 500,
-			"$$hashKey": "object:1789",
-			"user": "anonymous",
-			"dateFinished": "2017-08-17T14:22:18+0000",
-			"dateStarted": "2017-08-17T14:22:17+0000"
+			"$$hashKey": "object:4334"
 		},
 		{
 			"text": "%angular\r\n\r\n<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.css\" />\r\n<h3>Client-side Integration</h3>\r\n<div id=\"map2\" style=\"height: 600px; width: 100%\"></div>\r\n\r\n<script type=\"text/javascript\">\r\nfunction initMap2() {\r\n    var map2 = L.map('map2').setView([52.5, 13.4], 11);\r\n\r\n    L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {\r\n        attribution: 'Map data &copy; <a href=\"http://openstreetmap.org\">OpenStreetMap</a> contributors',\r\n        maxZoom: 15,\r\n        minZoom: 2\r\n    }).addTo(map2);\r\n\r\n    var geoMarkers = L.layerGroup().addTo(map2);\r\n    var markerIcon = L.icon({\r\n        iconUrl: 'https://openstationmap.org/0.2.0/client/leaflet/images/marker-icon.png',\r\n        iconSize: [24, 32],\r\n    });\r\n\r\n    var el = angular.element($('#map2').parent('.ng-scope'));\r\n    angular.element(el).ready(function() {\r\n        window.pinWatcher = el.scope().compiledScope.$watch('pins', function(pinList, oldValue) {\r\n            geoMarkers.clearLayers();\r\n            angular.forEach(pinList, function(pin) {\r\n                var marker = L.marker([ pin.lat, pin.lon ], {icon: markerIcon})\r\n                  .bindPopup(pin.data)\r\n                  .addTo(geoMarkers);\r\n            });\r\n        })\r\n    });}\r\n\r\nif (window.pinWatcher) {\r\n    // clear existing watcher otherwise we'll have duplicates\r\n    window.pinWatcher();\r\n}\r\n\r\n// ensure we only load the script once, seems to cause issues otherwise\r\nif (window.L) {\r\n    initMap2();\r\n} else {\r\n    console.log('Loading Leaflet library');\r\n    var sc = document.createElement('script');\r\n    sc.type = 'text/javascript';\r\n    sc.src = 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.js';\r\n    sc.onload = initMap2;\r\n    sc.onerror = function(err) { alert(err); }\r\n    document.getElementsByTagName('head')[0].appendChild(sc);\r\n}\r\n</script>",
-			"dateUpdated": "2017-08-17T14:23:57+0000",
+			"dateUpdated": "2017-09-14T11:04:09-0700",
 			"config": {
 				"tableHide": false,
 				"editorSetting": {
@@ -444,29 +430,55 @@
 			},
 			"apps": [
 			],
-			"jobName": "paragraph_1502978887597_-1742390455",
+			"jobName": "paragraph_1505412249537_-593620577",
 			"id": "20170809-021534_2122057818",
-			"dateCreated": "2017-08-17T14:08:07+0000",
-			"status": "FINISHED",
+			"dateCreated": "2017-09-14T11:04:09-0700",
+			"status": "READY",
+			"errorMessage": "",
 			"progressUpdateIntervalMs": 500,
-			"$$hashKey": "object:1790",
-			"user": "anonymous",
-			"dateFinished": "2017-08-17T14:23:57+0000",
-			"dateStarted": "2017-08-17T14:23:57+0000"
+			"$$hashKey": "object:4335"
 		}
 	],
-	"name": "GeoWave GPX KMeans",
-	"id": "2CREFHU51",
+	"name": "GeoWave GPX Demo",
+	"id": "2CTK23QFD",
 	"angularObjects": {
-		"2BRWU4WXC:shared_process": [
+		"2CQ45EQN3:shared_process": [
 		],
-		"2AM1YV5CU:shared_process": [
+		"2CRMR95VM:shared_process": [
 		],
-		"2AJXGMUUJ:shared_process": [
+		"2CR7HU4K5:shared_process": [
 		],
-		"2ANGGHHMQ:shared_process": [
+		"2CNZDBXB1:shared_process": [
 		],
-		"2AKK3QQXU:shared_process": [
+		"2CSSPJY6E:shared_process": [
+		],
+		"2CR9SXZU2:shared_process": [
+		],
+		"2CP794URS:shared_process": [
+		],
+		"2CS1T6Z8H:shared_process": [
+		],
+		"2CRRSU11A:shared_process": [
+		],
+		"2CQ6DYKSD:shared_process": [
+		],
+		"2CQUHQ6N9:shared_process": [
+		],
+		"2CSM6GRR3:shared_process": [
+		],
+		"2CRS36YKB:shared_process": [
+		],
+		"2CQDNDSDA:shared_process": [
+		],
+		"2CS7FBNVX:shared_process": [
+		],
+		"2CP5MBF4A:shared_process": [
+		],
+		"2CQQKN5PH:shared_process": [
+		],
+		"2CQDTRBTZ:shared_process": [
+		],
+		"2CR7ANRVS:shared_process": [
 		]
 	},
 	"config": {


### PR DESCRIPTION
The --cqlFilter param was already in the notebook. I added the QuickStart steps to download and ingest GDELT data. NOTE: This is NOT tested yet. We should leave this PR open until Jon or I have a chance to run through it on EMR.