### PR TITLE
Modifying bucket used for notebook examples

### DIFF
--- a/deploy/packaging/docker/publish/publish-common-rpm.sh
+++ b/deploy/packaging/docker/publish/publish-common-rpm.sh
@@ -71,7 +71,7 @@ if command -v aws >/dev/null 2>&1 ; then
 		aws s3 cp --acl public-read --recursive ${WORKSPACE}/deploy/packaging/sandbox/generated/ s3://geowave/${GEOWAVE_VERSION_URL}/scripts/sandbox/
 		
 		# Adding copy for example jupyter notebooks to s3 bucket. TODO: Will only use GDELT for now (gpx notebook not ready) should be entire notebook directory copy
-		aws s3 cp --acl public-read ${WORKSPACE}/examples/data/notebooks/jupyter/geowave-gdelt.ipynb s3://geowave/${GEOWAVE_VERSION_URL}/notebooks/geowave-gdelt.ipynb
+		aws s3 cp --acl public-read ${WORKSPACE}/examples/data/notebooks/jupyter/geowave-gdelt.ipynb s3://geowave-notebooks/${GEOWAVE_VERSION_URL}/notebooks/geowave-gdelt.ipynb
 	else
 		echo '###### Skipping publish to S3: GEOWAVE_VERSION_URL not defined'
 	fi

--- a/deploy/packaging/emr/template/bootstrap-jupyter.sh.template
+++ b/deploy/packaging/emr/template/bootstrap-jupyter.sh.template
@@ -24,7 +24,7 @@ fi
 wget https://repo.continuum.io/miniconda/Miniconda3-4.2.12-Linux-x86_64.sh -O $HOME/miniconda.sh
 
 # Download example notebooks from s3
-aws s3 sync s3://geowave/$GEOWAVE_VERSION_URL_TOKEN/notebooks/ $HOME/notebooks/
+aws s3 sync s3://geowave-notebooks/$GEOWAVE_VERSION_URL_TOKEN/notebooks/ $HOME/notebooks/
 
 # Modify the file permissions to allow execution within this shell
 chmod +x $HOME/miniconda.sh


### PR DESCRIPTION
Use geowave-notebooks instead of main geowave bucket. geowave-notebooks able to list objects.