### PR TITLE
Add hdfs url stream handler to classloader init

### DIFF
--- a/core/ingest/src/main/java/mil/nga/giat/geowave/core/ingest/IngestUtils.java
+++ b/core/ingest/src/main/java/mil/nga/giat/geowave/core/ingest/IngestUtils.java
@@ -10,13 +10,82 @@
  ******************************************************************************/
 package mil.nga.giat.geowave.core.ingest;
 
+import java.lang.reflect.Field;
+import java.net.URL;
+import java.net.URLStreamHandlerFactory;
 import java.util.List;
 
+import mil.nga.giat.geowave.core.ingest.hdfs.HdfsUrlStreamHandlerFactory;
+import mil.nga.giat.geowave.core.ingest.s3.S3URLStreamHandlerFactory;
 import mil.nga.giat.geowave.core.store.index.CommonIndexValue;
 import mil.nga.giat.geowave.core.store.operations.remote.options.IndexPluginOptions;
 
 public class IngestUtils
 {
+	public static enum URLTYPE {
+		S3,
+		HDFS
+	}
+
+	public static void setURLStreamHandlerFactory(
+			URLTYPE urlType )
+			throws NoSuchFieldException,
+			SecurityException,
+			IllegalArgumentException,
+			IllegalAccessException {
+
+		Field factoryField = URL.class.getDeclaredField("factory");
+		// HP Fortify "Access Control" false positive
+		// The need to change the accessibility here is
+		// necessary, has been review and judged to be safe
+		factoryField.setAccessible(true);
+
+		URLStreamHandlerFactory urlStreamHandlerFactory = (URLStreamHandlerFactory) factoryField.get(null);
+
+		if (urlStreamHandlerFactory == null) {
+			if (urlType == URLTYPE.S3) {
+				URL.setURLStreamHandlerFactory(new S3URLStreamHandlerFactory());
+			}
+			else { // HDFS
+				URL.setURLStreamHandlerFactory(new HdfsUrlStreamHandlerFactory());
+			}
+
+		}
+		else {
+			if (urlType == URLTYPE.S3) {
+				if (urlStreamHandlerFactory instanceof S3URLStreamHandlerFactory) {
+					return;
+				}
+			}
+			else { // HDFS
+				if (urlStreamHandlerFactory instanceof HdfsUrlStreamHandlerFactory) {
+					return;
+				}
+			}
+
+			Field lockField = URL.class.getDeclaredField("streamHandlerLock");
+			// HP Fortify "Access Control" false positive
+			// The need to change the accessibility here is
+			// necessary, has been review and judged to be safe
+			lockField.setAccessible(true);
+			synchronized (lockField.get(null)) {
+
+				factoryField.set(
+						null,
+						null);
+
+				if (urlType == URLTYPE.S3) {
+					URL.setURLStreamHandlerFactory(new S3URLStreamHandlerFactory(
+							urlStreamHandlerFactory));
+				}
+				else { // HDFS
+					URL.setURLStreamHandlerFactory(new HdfsUrlStreamHandlerFactory(
+							urlStreamHandlerFactory));
+				}
+			}
+		}
+	}
+
 	/**
 	 * Determine whether an index is compatible with the visitor
 	 * 

--- a/core/ingest/src/main/java/mil/nga/giat/geowave/core/ingest/hdfs/HdfsUrlStreamHandlerFactory.java
+++ b/core/ingest/src/main/java/mil/nga/giat/geowave/core/ingest/hdfs/HdfsUrlStreamHandlerFactory.java
@@ -1,0 +1,46 @@
+package mil.nga.giat.geowave.core.ingest.hdfs;
+
+import java.net.URLStreamHandler;
+import java.net.URLStreamHandlerFactory;
+import java.util.Optional;
+
+import org.apache.hadoop.fs.FsUrlStreamHandlerFactory;
+
+public class HdfsUrlStreamHandlerFactory extends
+		FsUrlStreamHandlerFactory
+{
+	// The wrapped URLStreamHandlerFactory's instance
+	private final Optional<URLStreamHandlerFactory> delegate;
+
+	/**
+	 * Used in case there is no existing URLStreamHandlerFactory defined
+	 */
+	public HdfsUrlStreamHandlerFactory() {
+		this(
+				null);
+	}
+
+	/**
+	 * Used in case there is an existing URLStreamHandlerFactory defined
+	 */
+	public HdfsUrlStreamHandlerFactory(
+			final URLStreamHandlerFactory delegate ) {
+		this.delegate = Optional.ofNullable(delegate);
+	}
+
+	@Override
+    public URLStreamHandler createURLStreamHandler(final String protocol) {
+		
+		// FsUrlStreamHandlerFactory impl
+		URLStreamHandler urlStreamHandler = super.createURLStreamHandler(protocol);
+		
+		// See if hadoop handled it
+        if (urlStreamHandler != null) {
+            return urlStreamHandler; 
+        }
+        
+        // It is not the hdfs protocol so we delegate it to the wrapped URLStreamHandlerFactory
+        return delegate.map(factory -> factory.createURLStreamHandler(protocol))
+            .orElse(null);
+    }
+}

--- a/extensions/datastores/accumulo/pom.xml
+++ b/extensions/datastores/accumulo/pom.xml
@@ -25,6 +25,11 @@
             <artifactId>geowave-core-cli</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>mil.nga.giat</groupId>
+            <artifactId>geowave-core-ingest</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 		<dependency>
 			<groupId>org.apache.accumulo</groupId>
 			<artifactId>accumulo-minicluster</artifactId>

--- a/extensions/datastores/hbase/src/main/java/mil/nga/giat/geowave/datastore/hbase/operations/BasicHBaseOperations.java
+++ b/extensions/datastores/hbase/src/main/java/mil/nga/giat/geowave/datastore/hbase/operations/BasicHBaseOperations.java
@@ -58,7 +58,7 @@ public class BasicHBaseOperations implements
 
 	private final Connection conn;
 	private final String tableNamespace;
-	private final boolean schemaUpdateEnabled;
+	private final boolean schemaUpdateEnabled = false; // KAM EXPERIMENTAL
 
 	public BasicHBaseOperations(
 			final Connection connection,
@@ -67,9 +67,10 @@ public class BasicHBaseOperations implements
 		conn = connection;
 		tableNamespace = geowaveNamespace;
 
-		schemaUpdateEnabled = conn.getConfiguration().getBoolean(
-				"hbase.online.schema.update.enable",
-				false);
+		// KAM EXPERIMENTAL
+		// schemaUpdateEnabled = conn.getConfiguration().getBoolean(
+		// "hbase.online.schema.update.enable",
+		// false);
 	}
 
 	public BasicHBaseOperations(
@@ -80,9 +81,10 @@ public class BasicHBaseOperations implements
 				zookeeperInstances);
 		tableNamespace = geowaveNamespace;
 
-		schemaUpdateEnabled = conn.getConfiguration().getBoolean(
-				"hbase.online.schema.update.enable",
-				false);
+		// KAM EXPERIMENTAL
+		// schemaUpdateEnabled = conn.getConfiguration().getBoolean(
+		// "hbase.online.schema.update.enable",
+		// false);
 	}
 
 	public static BasicHBaseOperations createOperations(


### PR DESCRIPTION
This is the fix for the issue where a WFS request w/ CQL filter was killing the tablet server.