### PR TITLE
Fix accumulo restservices war copy

### DIFF
--- a/deploy/packaging/docker/build-rpm/build-services-rpm.sh
+++ b/deploy/packaging/docker/build-rpm/build-services-rpm.sh
@@ -127,7 +127,9 @@ echo "Copy REST Services file"
 cp $WORKSPACE/services/rest/target/*${GEOWAVE_VERSION}-${VENDOR_VERSION}.war restservices.war
 
 # Copy accumulo 1.7 restservices war file 
-cp $WORKSPACE/services/rest/target/geowave-restservices-${GEOWAVE_VERSION}-${VENDOR_VERSION}-accumulo1.7.war $WORKSPACE/${ARGS[buildroot]}/SOURCES/geowave-restservices-${GEOWAVE_VERSION}-${VENDOR_VERSION}-accumulo1.7.war
+if [[ -f $WORKSPACE/services/rest/target/geowave-restservices-${GEOWAVE_VERSION}-${VENDOR_VERSION}-accumulo1.7.war ]]; then
+  cp $WORKSPACE/services/rest/target/geowave-restservices-${GEOWAVE_VERSION}-${VENDOR_VERSION}-accumulo1.7.war $WORKSPACE/${ARGS[buildroot]}/SOURCES/geowave-restservices-${GEOWAVE_VERSION}-${VENDOR_VERSION}-accumulo1.7.war
+fi
 
 #get geoserver the war files ready
 #unpack it in tmp dir


### PR DESCRIPTION
Test for existence of the accumulo restservices file before trying to copy it.  Fixes issue where script would terminate prematurely and not genereate restservices or geoserver rpms.