### PR TITLE
Refactor SparkSession & SparkConf use.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ script:
   # This script uses the IT_ONLY flag to determine whether to run unit tests using verify, or ITs only using failsafe
   - .utility/run-tests.sh
 before_install:
+  - sudo apt-get install lzop
   # This must match the dev-resources version from the parent pom:
   - export DEV_RESOURCES_VERSION=1.2
   - export MAVEN_OPTS="-XX:CompressedClassSpaceSize=256m -XX:+UseSerialGC -Xmx2g -XX:MaxMetaspaceSize=512m -Dorg.slf4j.simpleLogger.defaultLogLevel=warn"

--- a/analytics/spark/src/main/java/mil/nga/giat/geowave/analytic/spark/GeoWaveSparkConf.java
+++ b/analytics/spark/src/main/java/mil/nga/giat/geowave/analytic/spark/GeoWaveSparkConf.java
@@ -1,0 +1,57 @@
+package mil.nga.giat.geowave.analytic.spark;
+
+import java.io.Serializable;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.sql.SparkSession;
+
+//This class is used to create SparkConf and SparkSessions that will be compatible with GeoWave.
+public class GeoWaveSparkConf implements
+		Serializable
+{
+
+	// Returns a SparkConf with just the basic settings necessary for spark to
+	// work with GeoWave
+	public static SparkConf getDefaultConfig() {
+		SparkConf defaultConfig = new SparkConf();
+		defaultConfig = defaultConfig.setMaster("yarn");
+		defaultConfig = defaultConfig.set(
+				"spark.serializer",
+				"org.apache.spark.serializer.KryoSerializer");
+		defaultConfig = defaultConfig.set(
+				"spark.kryo.registrator",
+				"mil.nga.giat.geowave.analytic.spark.GeoWaveRegistrator");
+		return defaultConfig;
+	}
+
+	// Returns a *NEW* SparkConf with GeoWave default settings applied using
+	// userConf as base. *DOES NOT MODIFY PARAMETER*
+	public static SparkConf applyDefaultsToConfig(
+			SparkConf userConf ) {
+		SparkConf newConf = userConf.clone();
+		newConf = newConf.set(
+				"spark.serializer",
+				"org.apache.spark.serializer.KryoSerializer");
+		newConf = newConf.set(
+				"spark.kryo.registrator",
+				"mil.nga.giat.geowave.analytic.spark.GeoWaveRegistrator");
+		return newConf;
+	}
+
+	// Create a default SparkSession with GeoWave settings applied to config.
+	public static SparkSession createDefaultSession() {
+		SparkConf defaultConfig = GeoWaveSparkConf.getDefaultConfig();
+		return createDefaultSession(defaultConfig);
+	}
+
+	// Create a SparkSession with GeoWave settings and then user configuration
+	// options added on top of defaults.
+	public static SparkSession createDefaultSession(
+			SparkConf addonOptions ) {
+		SparkConf defaultConfig = GeoWaveSparkConf.getDefaultConfig();
+		return SparkSession.builder().config(
+				defaultConfig).config(
+				addonOptions).getOrCreate();
+	}
+
+}

--- a/analytics/spark/src/main/java/mil/nga/giat/geowave/analytic/spark/kmeans/KMeansRunner.java
+++ b/analytics/spark/src/main/java/mil/nga/giat/geowave/analytic/spark/kmeans/KMeansRunner.java
@@ -5,6 +5,7 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -27,6 +28,7 @@ import mil.nga.giat.geowave.adapter.vector.plugin.ExtractGeometryFilterVisitor;
 import mil.nga.giat.geowave.adapter.vector.plugin.ExtractGeometryFilterVisitorResult;
 import mil.nga.giat.geowave.adapter.vector.util.FeatureDataUtils;
 import mil.nga.giat.geowave.analytic.spark.GeoWaveRDD;
+import mil.nga.giat.geowave.analytic.spark.GeoWaveSparkConf;
 import mil.nga.giat.geowave.core.geotime.GeometryUtils;
 import mil.nga.giat.geowave.core.geotime.store.query.ScaledTemporalRange;
 import mil.nga.giat.geowave.core.geotime.store.query.SpatialQuery;
@@ -84,16 +86,17 @@ public class KMeansRunner
 						"Unable to set jar location in spark configuration",
 						e);
 			}
-			session = SparkSession.builder().appName(
-					appName).master(
-					master).config(
+			SparkConf addonOptions = new SparkConf();
+			addonOptions = addonOptions.setAppName(
+					appName).setMaster(
+					master).set(
 					"spark.driver.host",
-					host).config(
+					host).set(
 					"spark.jars",
-					jar).getOrCreate();
+					jar);
+			session = GeoWaveSparkConf.createDefaultSession(addonOptions);
 
-			jsc = new JavaSparkContext(
-					session.sparkContext());
+			jsc = JavaSparkContext.fromSparkContext(session.sparkContext());
 		}
 	}
 

--- a/analytics/spark/src/main/java/mil/nga/giat/geowave/analytic/spark/sparksql/SqlQueryRunner.java
+++ b/analytics/spark/src/main/java/mil/nga/giat/geowave/analytic/spark/sparksql/SqlQueryRunner.java
@@ -3,6 +3,7 @@ package mil.nga.giat.geowave.analytic.spark.sparksql;
 import java.io.IOException;
 import java.net.URISyntaxException;
 
+import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.Dataset;
@@ -13,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import mil.nga.giat.geowave.analytic.spark.GeoWaveRDD;
+import mil.nga.giat.geowave.analytic.spark.GeoWaveSparkConf;
 import mil.nga.giat.geowave.analytic.spark.kmeans.KMeansRunner;
 import mil.nga.giat.geowave.core.index.ByteArrayId;
 import mil.nga.giat.geowave.core.store.CloseableIterator;
@@ -55,16 +57,17 @@ public class SqlQueryRunner
 						"Unable to set jar location in spark configuration",
 						e);
 			}
-			session = SparkSession.builder().appName(
-					appName).master(
-					master).config(
+			SparkConf addonOptions = new SparkConf();
+			addonOptions = addonOptions.setAppName(
+					appName).setMaster(
+					master).set(
 					"spark.driver.host",
-					host).config(
+					host).set(
 					"spark.jars",
-					jar).getOrCreate();
+					jar);
+			session = GeoWaveSparkConf.createDefaultSession(addonOptions);
 
-			jsc = new JavaSparkContext(
-					session.sparkContext());
+			jsc = JavaSparkContext.fromSparkContext(session.sparkContext());
 		}
 	}
 
@@ -202,6 +205,11 @@ public class SqlQueryRunner
 		}
 
 		return null;
+	}
+
+	public void setJavaSparkContext(
+			final JavaSparkContext jsc ) {
+		this.jsc = jsc;
 	}
 
 	public void setAppName(

--- a/extensions/datastores/hbase/src/main/java/mil/nga/giat/geowave/datastore/hbase/HBaseDataStore.java
+++ b/extensions/datastores/hbase/src/main/java/mil/nga/giat/geowave/datastore/hbase/HBaseDataStore.java
@@ -106,9 +106,4 @@ public class HBaseDataStore extends
 		}
 
 	}
-
-	@Override
-	protected SplitsProvider createSplitsProvider() {
-		return new HBaseSplitsProvider();
-	}
 }

--- a/test/src/main/java/mil/nga/giat/geowave/test/annotation/Environments.java
+++ b/test/src/main/java/mil/nga/giat/geowave/test/annotation/Environments.java
@@ -19,6 +19,7 @@ import mil.nga.giat.geowave.test.TestEnvironment;
 import mil.nga.giat.geowave.test.kafka.KafkaTestEnvironment;
 import mil.nga.giat.geowave.test.mapreduce.MapReduceTestEnvironment;
 import mil.nga.giat.geowave.test.services.ServicesTestEnvironment;
+import mil.nga.giat.geowave.test.spark.SparkTestEnvironment;
 
 /**
  * The <code>Environments</code> annotation specifies the GeoWave test
@@ -42,7 +43,9 @@ public @interface Environments {
 		KAFKA(
 				KafkaTestEnvironment.getInstance()),
 		SERVICES(
-				ServicesTestEnvironment.getInstance());
+				ServicesTestEnvironment.getInstance()),
+		SPARK(
+				SparkTestEnvironment.getInstance());
 		private final TestEnvironment testEnvironment;
 
 		private Environment(

--- a/test/src/main/java/mil/nga/giat/geowave/test/spark/SparkTestEnvironment.java
+++ b/test/src/main/java/mil/nga/giat/geowave/test/spark/SparkTestEnvironment.java
@@ -1,0 +1,68 @@
+package mil.nga.giat.geowave.test.spark;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkContext;
+import org.apache.spark.sql.SparkSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import mil.nga.giat.geowave.analytic.spark.GeoWaveSparkConf;
+import mil.nga.giat.geowave.test.TestEnvironment;
+
+public class SparkTestEnvironment implements
+		TestEnvironment
+{
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(SparkTestEnvironment.class);
+
+	private static SparkTestEnvironment singletonInstance = null;
+	protected SparkSession defaultSession = null;
+	protected SparkContext defaultContext = null;
+
+	public static synchronized SparkTestEnvironment getInstance() {
+		if (singletonInstance == null) {
+			singletonInstance = new SparkTestEnvironment();
+		}
+		return singletonInstance;
+	}
+
+	@Override
+	public void setup()
+			throws Exception {
+		if(defaultSession == null) {
+			SparkConf addonOptions = new SparkConf();
+			addonOptions.setMaster("local[*]");
+			addonOptions.setAppName("CoreGeoWaveSparkITs");
+			defaultSession = GeoWaveSparkConf.createDefaultSession(addonOptions);
+			if (defaultSession == null) {
+				LOGGER.error("Unable to create default spark session for tests");
+				return;
+			}
+			defaultContext = defaultSession.sparkContext();
+		}
+	}
+
+	@Override
+	public void tearDown()
+			throws Exception {
+		if (defaultSession != null) {
+			defaultContext = null;
+			defaultSession.close();
+			defaultSession = null;
+		}
+	}
+
+	@Override
+	public TestEnvironment[] getDependentEnvironments() {
+		return new TestEnvironment[] {};
+	}
+
+	public SparkSession getDefaultSession() {
+		return defaultSession;
+	}
+
+	public SparkContext getDefaultContext() {
+		return defaultContext;
+	}
+
+}

--- a/test/src/test/java/mil/nga/giat/geowave/test/mapreduce/DBScanIT.java
+++ b/test/src/test/java/mil/nga/giat/geowave/test/mapreduce/DBScanIT.java
@@ -146,13 +146,28 @@ public class DBScanIT extends
 			getBuilder());
 
 	@Test
-	public void testDBScan()
-			throws Exception {
-		TestUtils.deleteAll(dataStorePluginOptions);
+	public void testDBScan() {
 		dataGenerator.setIncludePolygons(false);
-		ingest(dataStorePluginOptions.createDataStore());
-		runScan(new SpatialQuery(
-				dataGenerator.getBoundingRegion()));
+		try {
+			ingest(dataStorePluginOptions.createDataStore());
+		}
+		catch (IOException e1) {
+			e1.printStackTrace();
+			TestUtils.deleteAll(dataStorePluginOptions);
+			Assert.fail("Unable to ingest data in DBScanIT");
+		}
+
+		try {
+			runScan(new SpatialQuery(
+					dataGenerator.getBoundingRegion()));
+		}
+		catch (Exception e) {
+			e.printStackTrace();
+			TestUtils.deleteAll(dataStorePluginOptions);
+			Assert.fail("Exception during scan of DBScanIT");
+		}
+
+		TestUtils.deleteAll(dataStorePluginOptions);
 	}
 
 	private void runScan(

--- a/test/src/test/java/mil/nga/giat/geowave/test/spark/GeoWaveJavaSparkIT.java
+++ b/test/src/test/java/mil/nga/giat/geowave/test/spark/GeoWaveJavaSparkIT.java
@@ -14,9 +14,8 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 
-import org.apache.spark.SparkConf;
+import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaPairRDD;
-import org.apache.spark.api.java.JavaSparkContext;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -40,16 +39,20 @@ import mil.nga.giat.geowave.test.GeoWaveITRunner;
 import mil.nga.giat.geowave.test.TestUtils;
 import mil.nga.giat.geowave.test.TestUtils.DimensionalityType;
 import mil.nga.giat.geowave.test.TestUtils.ExpectedResults;
+import mil.nga.giat.geowave.test.annotation.Environments;
 import mil.nga.giat.geowave.test.annotation.GeoWaveTestStore;
+import mil.nga.giat.geowave.test.annotation.Environments.Environment;
 import mil.nga.giat.geowave.test.annotation.GeoWaveTestStore.GeoWaveStoreType;
 import mil.nga.giat.geowave.test.basic.AbstractGeoWaveBasicVectorIT;
 
 @RunWith(GeoWaveITRunner.class)
+@Environments({
+	Environment.SPARK
+})
 public class GeoWaveJavaSparkIT extends
 		AbstractGeoWaveBasicVectorIT
 {
-	private final static Logger LOGGER = LoggerFactory.getLogger(
-			GeoWaveJavaSparkIT.class);
+	private final static Logger LOGGER = LoggerFactory.getLogger(GeoWaveJavaSparkIT.class);
 
 	private static final String TEST_BOX_FILTER_FILE = TEST_FILTER_PACKAGE + "Box-Filter.shp";
 	private static final String TEST_POLYGON_FILTER_FILE = TEST_FILTER_PACKAGE + "Polygon-Filter.shp";
@@ -60,7 +63,10 @@ public class GeoWaveJavaSparkIT extends
 	private static final int TORNADO_COUNT = 1196;
 
 	@GeoWaveTestStore(value = {
-		GeoWaveStoreType.ACCUMULO
+		GeoWaveStoreType.ACCUMULO,
+		GeoWaveStoreType.BIGTABLE,
+		GeoWaveStoreType.DYNAMODB,
+		GeoWaveStoreType.CASSANDRA
 	})
 	protected DataStorePluginOptions dataStore;
 
@@ -70,52 +76,28 @@ public class GeoWaveJavaSparkIT extends
 	public static void reportTestStart() {
 		stopwatch.reset();
 		stopwatch.start();
-		LOGGER.warn(
-				"-----------------------------------------");
-		LOGGER.warn(
-				"*                                       *");
-		LOGGER.warn(
-				"*  RUNNING GeoWaveJavaSparkIT           *");
-		LOGGER.warn(
-				"*                                       *");
-		LOGGER.warn(
-				"-----------------------------------------");
+		LOGGER.warn("-----------------------------------------");
+		LOGGER.warn("*                                       *");
+		LOGGER.warn("*  RUNNING GeoWaveJavaSparkIT           *");
+		LOGGER.warn("*                                       *");
+		LOGGER.warn("-----------------------------------------");
 	}
 
 	@AfterClass
 	public static void reportTestFinish() {
 		stopwatch.stop();
-		LOGGER.warn(
-				"-----------------------------------------");
-		LOGGER.warn(
-				"*                                       *");
-		LOGGER.warn(
-				"* FINISHED GeoWaveJavaSparkIT           *");
-		LOGGER.warn(
-				"*         " + stopwatch.getTimeString() + " elapsed.             *");
-		LOGGER.warn(
-				"*                                       *");
-		LOGGER.warn(
-				"-----------------------------------------");
+		LOGGER.warn("-----------------------------------------");
+		LOGGER.warn("*                                       *");
+		LOGGER.warn("* FINISHED GeoWaveJavaSparkIT           *");
+		LOGGER.warn("*         " + stopwatch.getTimeString() + " elapsed.             *");
+		LOGGER.warn("*                                       *");
+		LOGGER.warn("-----------------------------------------");
 	}
 
 	@Test
 	public void testLoadRDD() {
 		// Set up Spark
-		SparkConf sparkConf = new SparkConf();
-
-		sparkConf.setAppName(
-				"GeoWaveRDD");
-		sparkConf.setMaster(
-				"local");
-		sparkConf.set(
-				"spark.kryo.registrator",
-				"mil.nga.giat.geowave.analytic.spark.GeoWaveRegistrator");
-		sparkConf.set(
-				"spark.serializer",
-				"org.apache.spark.serializer.KryoSerializer");
-		JavaSparkContext context = new JavaSparkContext(
-				sparkConf);
+		SparkContext context = SparkTestEnvironment.getInstance().getDefaultContext();
 
 		// ingest test points
 		TestUtils.testLocalIngest(
@@ -126,25 +108,22 @@ public class GeoWaveJavaSparkIT extends
 
 		try {
 			// get expected results (box filter)
-			final ExpectedResults expectedResults = TestUtils.getExpectedResults(
-					new URL[] {
-						new File(
-								HAIL_EXPECTED_BOX_FILTER_RESULTS_FILE).toURI().toURL()
-					});
+			final ExpectedResults expectedResults = TestUtils.getExpectedResults(new URL[] {
+				new File(
+						HAIL_EXPECTED_BOX_FILTER_RESULTS_FILE).toURI().toURL()
+			});
 
-			final DistributableQuery query = TestUtils.resourceToQuery(
-					new File(
-							TEST_BOX_FILTER_FILE).toURI().toURL());
+			final DistributableQuery query = TestUtils.resourceToQuery(new File(
+					TEST_BOX_FILTER_FILE).toURI().toURL());
 
 			// Load RDD using spatial query (bbox)
 			JavaPairRDD<GeoWaveInputKey, SimpleFeature> javaRdd = GeoWaveRDD.rddForSimpleFeatures(
-					context.sc(),
+					context,
 					dataStore,
 					query);
 
 			long count = javaRdd.count();
-			LOGGER.warn(
-					"DataStore loaded into RDD with " + count + " features.");
+			LOGGER.warn("DataStore loaded into RDD with " + count + " features.");
 
 			// Verify RDD count matches expected count
 			Assert.assertEquals(
@@ -153,34 +132,28 @@ public class GeoWaveJavaSparkIT extends
 		}
 		catch (final Exception e) {
 			e.printStackTrace();
-			TestUtils.deleteAll(
-					dataStore);
-			context.close();
-			Assert.fail(
-					"Error occurred while testing a bounding box query of spatial index: '" + e.getLocalizedMessage()
-							+ "'");
+			TestUtils.deleteAll(dataStore);
+			Assert.fail("Error occurred while testing a bounding box query of spatial index: '"
+					+ e.getLocalizedMessage() + "'");
 		}
 		try {
 			// get expected results (polygon filter)
-			final ExpectedResults expectedResults = TestUtils.getExpectedResults(
-					new URL[] {
-						new File(
-								HAIL_EXPECTED_POLYGON_FILTER_RESULTS_FILE).toURI().toURL()
-					});
+			final ExpectedResults expectedResults = TestUtils.getExpectedResults(new URL[] {
+				new File(
+						HAIL_EXPECTED_POLYGON_FILTER_RESULTS_FILE).toURI().toURL()
+			});
 
-			final DistributableQuery query = TestUtils.resourceToQuery(
-					new File(
-							TEST_POLYGON_FILTER_FILE).toURI().toURL());
+			final DistributableQuery query = TestUtils.resourceToQuery(new File(
+					TEST_POLYGON_FILTER_FILE).toURI().toURL());
 
 			// Load RDD using spatial query (poly)
 			JavaPairRDD<GeoWaveInputKey, SimpleFeature> javaRdd = GeoWaveRDD.rddForSimpleFeatures(
-					context.sc(),
+					context,
 					dataStore,
 					query);
 
 			long count = javaRdd.count();
-			LOGGER.warn(
-					"DataStore loaded into RDD with " + count + " features.");
+			LOGGER.warn("DataStore loaded into RDD with " + count + " features.");
 
 			Assert.assertEquals(
 					expectedResults.count,
@@ -188,11 +161,9 @@ public class GeoWaveJavaSparkIT extends
 		}
 		catch (final Exception e) {
 			e.printStackTrace();
-			TestUtils.deleteAll(
-					dataStore);
-			context.close();
-			Assert.fail(
-					"Error occurred while testing a polygon query of spatial index: '" + e.getLocalizedMessage() + "'");
+			TestUtils.deleteAll(dataStore);
+			Assert.fail("Error occurred while testing a polygon query of spatial index: '" + e.getLocalizedMessage()
+					+ "'");
 		}
 
 		// ingest test lines
@@ -209,25 +180,22 @@ public class GeoWaveJavaSparkIT extends
 
 		while (adapterIt.hasNext()) {
 			DataAdapter adapter = adapterIt.next();
-			String adapterName = StringUtils.stringFromBinary(
-					adapter.getAdapterId().getBytes());
+			String adapterName = StringUtils.stringFromBinary(adapter.getAdapterId().getBytes());
 
-			if (adapterName.equals(
-					"hail")) {
+			if (adapterName.equals("hail")) {
 				hailAdapter = adapter;
 			}
 			else {
 				tornadoAdapter = adapter;
 			}
 
-			LOGGER.warn(
-					"DataStore has feature adapter: " + adapterName);
+			LOGGER.warn("DataStore has feature adapter: " + adapterName);
 		}
 
 		// Load RDD using hail adapter
 		try {
 			JavaPairRDD<GeoWaveInputKey, SimpleFeature> javaRdd = GeoWaveRDD.rddForSimpleFeatures(
-					context.sc(),
+					context,
 					dataStore,
 					null,
 					new QueryOptions(
@@ -239,33 +207,27 @@ public class GeoWaveJavaSparkIT extends
 					HAIL_COUNT,
 					count);
 
-			LOGGER.warn(
-					"DataStore loaded into RDD with " + count + " features for adapter " + StringUtils.stringFromBinary(
-							hailAdapter.getAdapterId().getBytes()));
+			LOGGER.warn("DataStore loaded into RDD with " + count + " features for adapter "
+					+ StringUtils.stringFromBinary(hailAdapter.getAdapterId().getBytes()));
 		}
 		catch (IOException e) {
 			e.printStackTrace();
-			TestUtils.deleteAll(
-					dataStore);
-			context.close();
-			Assert.fail(
-					"Error occurred while loading RDD with adapter: '" + e.getLocalizedMessage() + "'");
+			TestUtils.deleteAll(dataStore);
+			Assert.fail("Error occurred while loading RDD with adapter: '" + e.getLocalizedMessage() + "'");
 		}
 
 		// Load RDD using tornado adapter
 		try {
 			JavaPairRDD<GeoWaveInputKey, SimpleFeature> javaRdd = GeoWaveRDD.rddForSimpleFeatures(
-					context.sc(),
+					context,
 					dataStore,
 					null,
 					new QueryOptions(
 							tornadoAdapter));
 
-			javaRdd = javaRdd.distinct();
 			long count = javaRdd.count();
-			LOGGER.warn(
-					"DataStore loaded into RDD with " + count + " features for adapter " + StringUtils.stringFromBinary(
-							tornadoAdapter.getAdapterId().getBytes()));
+			LOGGER.warn("DataStore loaded into RDD with " + count + " features for adapter "
+					+ StringUtils.stringFromBinary(tornadoAdapter.getAdapterId().getBytes()));
 
 			Assert.assertEquals(
 					TORNADO_COUNT,
@@ -273,18 +235,12 @@ public class GeoWaveJavaSparkIT extends
 		}
 		catch (IOException e) {
 			e.printStackTrace();
-			TestUtils.deleteAll(
-					dataStore);
-			context.close();
-			Assert.fail(
-					"Error occurred while loading RDD with adapter: '" + e.getLocalizedMessage() + "'");
+			TestUtils.deleteAll(dataStore);
+			Assert.fail("Error occurred while loading RDD with adapter: '" + e.getLocalizedMessage() + "'");
 		}
 
 		// Clean up
-		TestUtils.deleteAll(
-				dataStore);
-
-		context.close();
+		TestUtils.deleteAll(dataStore);
 	}
 
 	@Override

--- a/test/src/test/java/mil/nga/giat/geowave/test/spark/GeoWaveJavaSparkKMeansIT.java
+++ b/test/src/test/java/mil/nga/giat/geowave/test/spark/GeoWaveJavaSparkKMeansIT.java
@@ -13,7 +13,9 @@ package mil.nga.giat.geowave.test.spark;
 import java.io.IOException;
 import java.util.Date;
 
+import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.mllib.clustering.KMeansModel;
 import org.apache.spark.mllib.linalg.Vector;
 import org.junit.AfterClass;
@@ -30,9 +32,7 @@ import com.vividsolutions.jts.geom.Geometry;
 
 import mil.nga.giat.geowave.analytic.spark.kmeans.KMeansHullGenerator;
 import mil.nga.giat.geowave.analytic.spark.kmeans.KMeansRunner;
-import mil.nga.giat.geowave.analytic.spark.kmeans.KMeansUtils;
 import mil.nga.giat.geowave.core.geotime.TimeUtils;
-import mil.nga.giat.geowave.core.geotime.store.query.ScaledTemporalRange;
 import mil.nga.giat.geowave.core.index.ByteArrayId;
 import mil.nga.giat.geowave.core.index.StringUtils;
 import mil.nga.giat.geowave.core.store.CloseableIterator;
@@ -44,11 +44,16 @@ import mil.nga.giat.geowave.core.store.query.QueryOptions;
 import mil.nga.giat.geowave.test.GeoWaveITRunner;
 import mil.nga.giat.geowave.test.TestUtils;
 import mil.nga.giat.geowave.test.TestUtils.DimensionalityType;
+import mil.nga.giat.geowave.test.annotation.Environments;
 import mil.nga.giat.geowave.test.annotation.GeoWaveTestStore;
+import mil.nga.giat.geowave.test.annotation.Environments.Environment;
 import mil.nga.giat.geowave.test.annotation.GeoWaveTestStore.GeoWaveStoreType;
 import scala.Tuple2;
 
 @RunWith(GeoWaveITRunner.class)
+@Environments({
+	Environment.SPARK
+})
 public class GeoWaveJavaSparkKMeansIT
 {
 	private final static Logger LOGGER = LoggerFactory.getLogger(GeoWaveJavaSparkKMeansIT.class);
@@ -58,7 +63,10 @@ public class GeoWaveJavaSparkKMeansIT
 	protected static final String CQL_FILTER = "BBOX(the_geom, -100, 30, -90, 40)";
 
 	@GeoWaveTestStore(value = {
-		GeoWaveStoreType.ACCUMULO
+		GeoWaveStoreType.ACCUMULO,
+		GeoWaveStoreType.BIGTABLE,
+		GeoWaveStoreType.DYNAMODB,
+		GeoWaveStoreType.CASSANDRA
 	})
 	protected DataStorePluginOptions inputDataStore;
 
@@ -88,7 +96,7 @@ public class GeoWaveJavaSparkKMeansIT
 
 	@Test
 	public void testKMeansRunner() {
-		TestUtils.deleteAll(inputDataStore);
+		SparkContext context = SparkTestEnvironment.getInstance().getDefaultContext();
 
 		// Load data
 		TestUtils.testLocalIngest(
@@ -100,26 +108,20 @@ public class GeoWaveJavaSparkKMeansIT
 		String adapterId = "hail";
 
 		// Create the runner
+		long mark = System.currentTimeMillis();
 		final KMeansRunner runner = new KMeansRunner();
+		runner.setJavaSparkContext(JavaSparkContext.fromSparkContext(context));
 		runner.setInputDataStore(inputDataStore);
 		runner.setAdapterId(adapterId);
 		runner.setCqlFilter(CQL_FILTER);
-		runner.setMaster("local[*]");
+		runner.setUseTime(true);
+		// Set output params to write centroids + hulls to store.
+		runner.setOutputDataStore(inputDataStore);
+		runner.setCentroidTypeName("kmeans-centroids-test");
 
-		// Attempt to set the time params
-		ScaledTemporalRange scaledRange = KMeansUtils.setRunnerTimeParams(
-				runner,
-				inputDataStore,
-				new ByteArrayId(
-						adapterId));
-
-		if (scaledRange == null) {
-			Assert.fail("Failed to set time params");
-
-			TestUtils.deleteAll(inputDataStore);
-
-			runner.close();
-		}
+		runner.setGenerateHulls(true);
+		runner.setComputeHullData(true);
+		runner.setHullTypeName("kmeans-hulls-test");
 
 		// Run kmeans
 		try {
@@ -133,17 +135,20 @@ public class GeoWaveJavaSparkKMeansIT
 		// Create the output
 		final KMeansModel clusterModel = runner.getOutputModel();
 
+		long dur = (System.currentTimeMillis() - mark);
+		LOGGER.warn("KMeans duration: " + dur + " ms.");
 		// Write out the centroid features
-		DataAdapter centroidAdapter = KMeansUtils.writeClusterCentroids(
-				clusterModel,
-				inputDataStore,
-				"kmeans-centroids-test",
-				scaledRange);
+		DataAdapter centroidAdapter = inputDataStore.createAdapterStore().getAdapter(
+				new ByteArrayId(
+						"kmeans-centroids-test"));
 
 		// Query back from the new adapter
+		mark = System.currentTimeMillis();
 		queryFeatures(
 				centroidAdapter,
 				clusterModel.clusterCenters().length);
+		dur = (System.currentTimeMillis() - mark);
+		LOGGER.warn("Centroid verify: " + dur + " ms.");
 
 		// Generate the hulls
 		final JavaPairRDD<Integer, Iterable<Vector>> groupByRDD = KMeansHullGenerator.groupByIndex(
@@ -164,21 +169,20 @@ public class GeoWaveJavaSparkKMeansIT
 		}
 
 		// Write out the hull features w/ metadata
-		DataAdapter hullAdapter = KMeansUtils.writeClusterHulls(
-				runner.getInputCentroids(),
-				clusterModel,
-				inputDataStore,
-				"kmeans-hulls-test",
-				true);
+		DataAdapter hullAdapter = inputDataStore.createAdapterStore().getAdapter(
+				new ByteArrayId(
+						"kmeans-hulls-test"));
 
+		mark = System.currentTimeMillis();
 		// Query back from the new adapter
 		queryFeatures(
 				hullAdapter,
 				clusterModel.clusterCenters().length);
+		dur = (System.currentTimeMillis() - mark);
+		LOGGER.warn("Hull verify: " + dur + " ms.");
 
 		TestUtils.deleteAll(inputDataStore);
 
-		runner.close();
 	}
 
 	private void queryFeatures(

--- a/test/src/test/java/mil/nga/giat/geowave/test/spark/GeoWaveJavaSparkSQLIT.java
+++ b/test/src/test/java/mil/nga/giat/geowave/test/spark/GeoWaveJavaSparkSQLIT.java
@@ -1,7 +1,7 @@
 package mil.nga.giat.geowave.test.spark;
 
+import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaPairRDD;
-import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
@@ -21,25 +21,32 @@ import com.vividsolutions.jts.util.Stopwatch;
 import mil.nga.giat.geowave.analytic.spark.GeoWaveRDD;
 import mil.nga.giat.geowave.analytic.spark.sparksql.SimpleFeatureDataFrame;
 import mil.nga.giat.geowave.analytic.spark.sparksql.SqlResultsWriter;
-import mil.nga.giat.geowave.analytic.spark.sparksql.util.GeomWriter;
 import mil.nga.giat.geowave.core.geotime.store.query.SpatialQuery;
 import mil.nga.giat.geowave.core.store.cli.remote.options.DataStorePluginOptions;
 import mil.nga.giat.geowave.mapreduce.input.GeoWaveInputKey;
 import mil.nga.giat.geowave.test.GeoWaveITRunner;
 import mil.nga.giat.geowave.test.TestUtils;
 import mil.nga.giat.geowave.test.TestUtils.DimensionalityType;
+import mil.nga.giat.geowave.test.annotation.Environments;
 import mil.nga.giat.geowave.test.annotation.GeoWaveTestStore;
+import mil.nga.giat.geowave.test.annotation.Environments.Environment;
 import mil.nga.giat.geowave.test.annotation.GeoWaveTestStore.GeoWaveStoreType;
 import mil.nga.giat.geowave.test.basic.AbstractGeoWaveBasicVectorIT;
 
 @RunWith(GeoWaveITRunner.class)
+@Environments({
+	Environment.SPARK
+})
 public class GeoWaveJavaSparkSQLIT extends
 		AbstractGeoWaveBasicVectorIT
 {
 	private final static Logger LOGGER = LoggerFactory.getLogger(GeoWaveJavaSparkSQLIT.class);
 
 	@GeoWaveTestStore(value = {
-		GeoWaveStoreType.ACCUMULO		
+		GeoWaveStoreType.ACCUMULO,
+		GeoWaveStoreType.BIGTABLE,
+		GeoWaveStoreType.DYNAMODB,
+		GeoWaveStoreType.CASSANDRA
 	})
 	protected DataStorePluginOptions dataStore;
 
@@ -70,12 +77,8 @@ public class GeoWaveJavaSparkSQLIT extends
 	@Test
 	public void testCreateDataFrame() {
 		// Set up Spark
-		SparkSession spark = SparkSession.builder().master(
-				"local[*]").appName(
-				"JavaSparkSqlIT").getOrCreate();
-
-		JavaSparkContext context = new JavaSparkContext(
-				spark.sparkContext());
+		SparkContext context = SparkTestEnvironment.getInstance().getDefaultContext();
+		SparkSession session = SparkTestEnvironment.getInstance().getDefaultSession();
 
 		// ingest test points
 		TestUtils.testLocalIngest(
@@ -87,7 +90,7 @@ public class GeoWaveJavaSparkSQLIT extends
 		try {
 			// Load RDD from datastore, no filters
 			JavaPairRDD<GeoWaveInputKey, SimpleFeature> javaRdd = GeoWaveRDD.rddForSimpleFeatures(
-					context.sc(),
+					context,
 					dataStore);
 
 			long count = javaRdd.count();
@@ -95,7 +98,7 @@ public class GeoWaveJavaSparkSQLIT extends
 
 			// Create a DataFrame from the RDD
 			SimpleFeatureDataFrame sfDataFrame = new SimpleFeatureDataFrame(
-					spark);
+					session);
 
 			if (!sfDataFrame.init(
 					dataStore,
@@ -112,11 +115,11 @@ public class GeoWaveJavaSparkSQLIT extends
 
 			String bbox = "POLYGON ((-94 34, -93 34, -93 35, -94 35, -94 34))";
 
-			Dataset<Row> results = spark.sql("SELECT * FROM features WHERE geomContains('" + bbox + "', geom)");
+			Dataset<Row> results = session.sql("SELECT * FROM features WHERE geomContains('" + bbox + "', geom)");
 			long containsCount = results.count();
 			LOGGER.warn("Got " + containsCount + " for geomContains test");
 
-			results = spark.sql("SELECT * FROM features WHERE geomWithin(geom, '" + bbox + "')");
+			results = session.sql("SELECT * FROM features WHERE geomWithin(geom, '" + bbox + "')");
 			long withinCount = results.count();
 			LOGGER.warn("Got " + withinCount + " for geomWithin test");
 
@@ -134,7 +137,7 @@ public class GeoWaveJavaSparkSQLIT extends
 			// Test other spatial UDFs
 			String line1 = "LINESTRING(0 0, 10 10)";
 			String line2 = "LINESTRING(0 10, 10 0)";
-			Row result = spark.sql(
+			Row result = session.sql(
 					"SELECT geomIntersects('" + line1 + "', '" + line2 + "')").head();
 
 			boolean intersect = result.getBoolean(0);
@@ -144,7 +147,7 @@ public class GeoWaveJavaSparkSQLIT extends
 					"Lines should intersect",
 					intersect);
 
-			result = spark.sql(
+			result = session.sql(
 					"SELECT geomDisjoint('" + line1 + "', '" + line2 + "')").head();
 
 			boolean disjoint = result.getBoolean(0);
@@ -158,28 +161,19 @@ public class GeoWaveJavaSparkSQLIT extends
 		catch (final Exception e) {
 			e.printStackTrace();
 			TestUtils.deleteAll(dataStore);
-			spark.close();
-			context.close();
 			Assert.fail("Error occurred while testing a bounding box query of spatial index: '"
 					+ e.getLocalizedMessage() + "'");
 		}
 
 		// Clean up
 		TestUtils.deleteAll(dataStore);
-
-		spark.close();
-		context.close();
 	}
 
 	// @Test
 	public void testSpatialJoin() {
 		// Set up Spark
-		SparkSession spark = SparkSession.builder().master(
-				"local[*]").appName(
-				"JavaSparkSqlIT").getOrCreate();
-
-		JavaSparkContext context = new JavaSparkContext(
-				spark.sparkContext());
+		SparkContext context = SparkTestEnvironment.getInstance().getDefaultContext();
+		SparkSession session = SparkTestEnvironment.getInstance().getDefaultSession();
 
 		// ingest test points
 		TestUtils.testLocalIngest(
@@ -198,13 +192,13 @@ public class GeoWaveJavaSparkSQLIT extends
 					leftBox);
 
 			JavaPairRDD<GeoWaveInputKey, SimpleFeature> leftRdd = GeoWaveRDD.rddForSimpleFeatures(
-					context.sc(),
+					context,
 					dataStore,
 					leftBoxQuery);
 
 			// Create a DataFrame from the Left RDD
 			SimpleFeatureDataFrame leftDataFrame = new SimpleFeatureDataFrame(
-					spark);
+					session);
 
 			if (!leftDataFrame.init(
 					dataStore,
@@ -216,7 +210,7 @@ public class GeoWaveJavaSparkSQLIT extends
 
 			dfLeft.createOrReplaceTempView("left");
 
-			Dataset<Row> leftDistinct = spark.sql("SELECT distinct geom FROM left");
+			Dataset<Row> leftDistinct = session.sql("SELECT distinct geom FROM left");
 
 			long leftCount = leftDistinct.count();
 			LOGGER.warn("Left dataframe loaded with " + leftCount + " unique points.");
@@ -228,13 +222,13 @@ public class GeoWaveJavaSparkSQLIT extends
 					rightBox);
 
 			JavaPairRDD<GeoWaveInputKey, SimpleFeature> rightRdd = GeoWaveRDD.rddForSimpleFeatures(
-					context.sc(),
+					context,
 					dataStore,
 					rightBoxQuery);
 
 			// Create a DataFrame from the Left RDD
 			SimpleFeatureDataFrame rightDataFrame = new SimpleFeatureDataFrame(
-					spark);
+					session);
 
 			if (!rightDataFrame.init(
 					dataStore,
@@ -246,13 +240,13 @@ public class GeoWaveJavaSparkSQLIT extends
 
 			dfRight.createOrReplaceTempView("right");
 
-			Dataset<Row> rightDistinct = spark.sql("SELECT distinct geom FROM right");
+			Dataset<Row> rightDistinct = session.sql("SELECT distinct geom FROM right");
 
 			long rightCount = rightDistinct.count();
 			LOGGER.warn("Right dataframe loaded with " + rightCount + " unique points.");
 
 			// Do a spatial join to find the overlap
-			Dataset<Row> results = spark
+			Dataset<Row> results = session
 					.sql("SELECT distinct left.geom FROM left INNER JOIN right ON geomIntersects(left.geom, right.geom)");
 
 			long overlapCount = results.count();
@@ -261,17 +255,12 @@ public class GeoWaveJavaSparkSQLIT extends
 		catch (final Exception e) {
 			e.printStackTrace();
 			TestUtils.deleteAll(dataStore);
-			spark.close();
-			context.close();
 			Assert.fail("Error occurred while testing a bounding box query of spatial index: '"
 					+ e.getLocalizedMessage() + "'");
 		}
 
 		// Clean up
 		TestUtils.deleteAll(dataStore);
-
-		spark.close();
-		context.close();
 	}
 
 	@Override


### PR DESCRIPTION
Add additional test annotations for new stores.
Removes use of HBaseSplitProvider, currently causing duplicate features to be loaded into RDDs for Spark.