### PR TITLE
Add options to gpx ingest to simplify geometry

### DIFF
--- a/extensions/formats/gpx/src/main/java/mil/nga/giat/geowave/format/gpx/GeometrySimpOptionProvider.java
+++ b/extensions/formats/gpx/src/main/java/mil/nga/giat/geowave/format/gpx/GeometrySimpOptionProvider.java
@@ -1,0 +1,61 @@
+package mil.nga.giat.geowave.format.gpx;
+
+import com.beust.jcommander.Parameter;
+
+import mil.nga.giat.geowave.core.index.persist.Persistable;
+
+public class GeometrySimpOptionProvider implements
+Persistable
+{
+	@Parameter(names = "--maxVertices", description = "Maximum number of vertices to allow for the feature. Features with over this vertice count will be discarded.")
+	private int maxVertices = 500;
+	
+	@Parameter(names = "--minSimpVertices", description = "Minimum vertex count to qualify for geometry simplification.")
+	private int simpLimit = 20;
+	
+	@Parameter(names = "--tolerance", description = "Maximum error tolerance in geometry simplification. Should range from 0.0 to 1.0 (i.e. .1 = 10%)")
+	private double tolerance = 0.02;
+	
+	@Parameter(names = "--maxLength", description = "Maximum line length for gpx track in degrees.")
+	private double lineLength = 10.0;
+
+	@Override
+	public byte[] toBinary() {
+		return new byte[] {
+			(byte)maxVertices,
+			(byte)simpLimit,
+			(byte)tolerance,
+			(byte)lineLength
+		};
+	}
+
+	@Override
+	public void fromBinary(
+			byte[] bytes ) {
+		int offset = 0;
+		maxVertices = (int)bytes[offset];
+		offset += 4;
+		simpLimit = (int)bytes[offset];
+		offset += 4;
+		tolerance = (double)bytes[offset];
+		offset += 4;
+		lineLength = (double)bytes[offset];
+	}
+
+	public int getMaxVertices() {
+		return maxVertices;
+	}
+
+	public int getSimpLimit() {
+		return simpLimit;
+	}
+
+	public double getTolerance() {
+		return tolerance;
+	}
+	
+	public double getMaxLength() {
+		return lineLength;
+	}
+
+}

--- a/extensions/formats/gpx/src/main/java/mil/nga/giat/geowave/format/gpx/GpxIngestFormat.java
+++ b/extensions/formats/gpx/src/main/java/mil/nga/giat/geowave/format/gpx/GpxIngestFormat.java
@@ -11,7 +11,11 @@
 package mil.nga.giat.geowave.format.gpx;
 
 import mil.nga.giat.geowave.adapter.vector.ingest.AbstractSimpleFeatureIngestPlugin;
+import mil.nga.giat.geowave.adapter.vector.ingest.SimpleFeatureIngestOptions;
 import mil.nga.giat.geowave.core.ingest.spi.IngestFormatOptionProvider;
+
+import com.beust.jcommander.ParametersDelegate;
+
 import mil.nga.giat.geowave.adapter.vector.ingest.AbstractSimpleFeatureIngestFormat;
 
 /**
@@ -22,10 +26,14 @@ import mil.nga.giat.geowave.adapter.vector.ingest.AbstractSimpleFeatureIngestFor
 public class GpxIngestFormat extends
 		AbstractSimpleFeatureIngestFormat<GpxTrack>
 {
+	private final GeometrySimpOptionProvider simplifyOptProvider = new GeometrySimpOptionProvider();
+	
 	@Override
 	protected AbstractSimpleFeatureIngestPlugin<GpxTrack> newPluginInstance(
 			IngestFormatOptionProvider options ) {
-		return new GpxIngestPlugin();
+		GpxIngestPlugin plugin = new GpxIngestPlugin();
+		plugin.setSimplifyOptionProvider(simplifyOptProvider);
+		return plugin;
 	}
 
 	@Override
@@ -36,6 +44,11 @@ public class GpxIngestFormat extends
 	@Override
 	public String getIngestFormatDescription() {
 		return "xml files adhering to the schema of gps exchange format";
+	}
+	
+	@Override
+	protected Object internalGetIngestFormatOptionProviders() {
+		return simplifyOptProvider;
 	}
 
 }

--- a/extensions/formats/gpx/src/main/java/mil/nga/giat/geowave/format/gpx/GpxIngestPlugin.java
+++ b/extensions/formats/gpx/src/main/java/mil/nga/giat/geowave/format/gpx/GpxIngestPlugin.java
@@ -67,6 +67,8 @@ public class GpxIngestPlugin extends
 	private final static Logger LOGGER = LoggerFactory.getLogger(GpxIngestPlugin.class);
 
 	private final static String TAG_SEPARATOR = " ||| ";
+	
+	private GeometrySimpOptionProvider simplifyOptProvider = null;
 
 	private Map<Long, GpxTrack> metadata = null;
 	private static final AtomicLong currentFreeTrackId = new AtomicLong(
@@ -224,7 +226,11 @@ public class GpxIngestPlugin extends
 					getAdditionalData(gpxTrack),
 					false, // waypoints, even dups, are unique, due to QGis
 							// behavior
-					globalVisibility);
+					globalVisibility,
+					this.simplifyOptProvider.getMaxVertices(),
+					this.simplifyOptProvider.getSimpLimit(),
+					this.simplifyOptProvider.getTolerance(),
+					this.simplifyOptProvider.getMaxLength());
 		}
 		catch (final Exception e) {
 			LOGGER.warn(
@@ -312,5 +318,10 @@ public class GpxIngestPlugin extends
 			GeometryWrapper.class,
 			Time.class
 		};
+	}
+
+	public void setSimplifyOptionProvider(
+			GeometrySimpOptionProvider simplifyOptProvider ) {
+		this.simplifyOptProvider = simplifyOptProvider;
 	}
 }

--- a/extensions/formats/gpx/src/main/java/mil/nga/giat/geowave/format/gpx/GpxPersistableRegistry.java
+++ b/extensions/formats/gpx/src/main/java/mil/nga/giat/geowave/format/gpx/GpxPersistableRegistry.java
@@ -26,6 +26,9 @@ public class GpxPersistableRegistry implements
 			new PersistableIdAndConstructor(
 					(short) 1201,
 					IngestGpxTrackFromHdfs::new),
+			new PersistableIdAndConstructor(
+					(short) 1202,
+					GeometrySimpOptionProvider::new)
 		};
 	}
 }

--- a/extensions/formats/gpx/src/test/java/mil/nga/giat/geowave/types/gpx/GPXConsumerTest.java
+++ b/extensions/formats/gpx/src/test/java/mil/nga/giat/geowave/types/gpx/GPXConsumerTest.java
@@ -206,7 +206,11 @@ public class GPXConsumerTest
 					"123",
 					new HashMap<String, Map<String, String>>(),
 					true,
-					"");
+					"",
+					Integer.MAX_VALUE,
+					Integer.MAX_VALUE,
+					0.0,
+					Double.MAX_VALUE);
 			int totalCount = 0;
 
 			while (consumer.hasNext()) {
@@ -285,7 +289,12 @@ public class GPXConsumerTest
 						"",
 						new HashMap<String, Map<String, String>>(),
 						false,
-						"")) {
+						"",
+						Integer.MAX_VALUE,
+						Integer.MAX_VALUE,
+						0.0,
+						Double.MAX_VALUE
+						)) {
 					final Set<String> ids = new HashSet<String>();
 					while (consumer.hasNext()) {
 						final String id = consumer.next().getValue().getID();


### PR DESCRIPTION
and exclude tracks that are too complex or cover too much area. 
Simplfication still needs to be moved to generalized option provider within AbstractSimpleFeatureIngest.