### PR TITLE
Enable batch correlation of uploaded files

### DIFF
--- a/services/rest/src/main/java/mil/nga/giat/geowave/service/rest/FileUploadResource.java
+++ b/services/rest/src/main/java/mil/nga/giat/geowave/service/rest/FileUploadResource.java
@@ -1,12 +1,16 @@
 package mil.nga.giat.geowave.service.rest;
 
 import java.io.File;
-import java.util.Arrays;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
+import java.util.UUID;
 
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.disk.DiskFileItemFactory;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
 import org.restlet.data.MediaType;
 import org.restlet.data.Status;
 import org.restlet.ext.fileupload.RestletFileUpload;
@@ -21,6 +25,8 @@ import org.restlet.resource.ServerResource;
 public class FileUploadResource extends
 		ServerResource
 {
+	private static final String KEY_BATCH_UUID = "batchUUID";
+
 	private static class UploadedFile
 	{
 		private final String name;
@@ -69,15 +75,17 @@ public class FileUploadResource extends
 			// 3/ Request is parsed by the handler which generates a
 			// list of FileItems
 			final String tempDir = System.getProperty("java.io.tmpdir");
+			final Path batchDir = Files.createDirectories(Paths.get(
+					tempDir,
+					createBatchDirname()));
+
 			// HP Fortify "Path Traversal" false positive
 			// A user would need to have OS-level access anyway
 			// to change the system properties
-			final File dir = new File(
-					tempDir);
-			final File filename = File.createTempFile(
-					"uploadedfile-",
-					"-" + item.getName(),
-					dir);
+			final File filename = Files.createTempFile(
+					batchDir,
+					"",
+					"." + item.getName()).toFile();
 			result = new UploadedFile(
 					filename.getAbsolutePath());
 			FileUtils.copyInputStreamToFile(
@@ -103,4 +111,27 @@ public class FileUploadResource extends
 				true);
 	}
 
+	private String createBatchDirname() {
+		final UUID uuid;
+		final String provided = StringUtils.trimToEmpty(getQueryValue(KEY_BATCH_UUID));
+		if (provided.isEmpty()) {
+			uuid = UUID.randomUUID();
+		}
+		else {
+			try {
+				uuid = UUID.fromString(provided);
+			}
+			catch (IllegalArgumentException e) {
+				throw new ResourceException(
+						Status.CLIENT_ERROR_BAD_REQUEST,
+						String.format(
+								"'%s' must be a valid UUID",
+								KEY_BATCH_UUID));
+			}
+		}
+
+		return String.format(
+				"upload-batch.%s",
+				uuid);
+	}
 }


### PR DESCRIPTION
This change allows an external consumer of the REST API to submit files in a
batch and ingest them in a single shot as opposed to submitting a single
ingest job per file.

Currently `geowave ingest localToGw` only accepts a single file or a directory
as the source parameter.  Doing "batch" ingests by transferring files via
`/restservices/v0/fileupload` would require invoking `localToGw` once for
every file in the batch which seems like it would require extra bookkeeping to
track and merge the operation statuses.

Refer to G3-297