### PR TITLE
Implement JupyterHub deployment with GEOAxis authentication

### DIFF
--- a/deploy/packaging/emr/generate-emr-scripts.sh
+++ b/deploy/packaging/emr/generate-emr-scripts.sh
@@ -48,8 +48,11 @@ mkdir -p $TARGET_ROOT/quickstart
 cp $TEMPLATE_ROOT/bootstrap-geowave.sh.template $TEMPLATE_ROOT/bootstrap-geowave.sh
 cp $TEMPLATE_ROOT/geowave-install-lib.sh.template $TEMPLATE_ROOT/geowave-install-lib.sh
 cp $TEMPLATE_ROOT/quickstart/geowave-env.sh.template $TARGET_ROOT/quickstart/geowave-env.sh
-cp $TEMPLATE_ROOT/bootstrap-jupyter.sh.template $TEMPLATE_ROOT/bootstrap-jupyter.sh
-cp $TEMPLATE_ROOT/create-configure-kernel.sh.template $TEMPLATE_ROOT/create-configure-kernel.sh
+
+cp $TEMPLATE_ROOT/jupyter/bootstrap-jupyter.sh.template $TEMPLATE_ROOT/bootstrap-jupyter.sh
+cp $TEMPLATE_ROOT/jupyter/create-configure-kernel.sh.template $TEMPLATE_ROOT/create-configure-kernel.sh
+cp $TEMPLATE_ROOT/jupyter/bootstrap-jupyterhub.sh.template $TEMPLATE_ROOT/bootstrap-jupyterhub.sh
+
 cp $TEMPLATE_ROOT/bootstrap-zeppelin.sh.template $TEMPLATE_ROOT/bootstrap-zeppelin.sh
 cp $TEMPLATE_ROOT/configure-zeppelin.sh.template $TEMPLATE_ROOT/configure-zeppelin.sh
 
@@ -71,6 +74,9 @@ sed -i -e s/'$GEOWAVE_VERSION_TOKEN'/${ARGS[version]}/g $TARGET_ROOT/quickstart/
 sed -i -e s/'$GEOWAVE_VERSION_TOKEN'/${ARGS[version]}/g $TEMPLATE_ROOT/bootstrap-jupyter.sh
 sed -i -e s/'$GEOWAVE_VERSION_URL_TOKEN'/${GEOWAVE_VERSION_URL_TOKEN}/g $TEMPLATE_ROOT/bootstrap-jupyter.sh
 sed -i -e s/'$GEOWAVE_VERSION_TOKEN'/${ARGS[version]}/g $TEMPLATE_ROOT/create-configure-kernel.sh
+
+sed -i -e s/'$GEOWAVE_VERSION_TOKEN'/${ARGS[version]}/g $TEMPLATE_ROOT/bootstrap-jupyterhub.sh
+sed -i -e s/'$GEOWAVE_VERSION_URL_TOKEN'/${GEOWAVE_VERSION_URL_TOKEN}/g $TEMPLATE_ROOT/bootstrap-jupyterhub.sh
 
 sed -i -e s/'$GEOWAVE_VERSION_TOKEN'/${ARGS[version]}/g $TEMPLATE_ROOT/bootstrap-zeppelin.sh
 sed -i -e s/'$GEOWAVE_VERSION_URL_TOKEN'/${GEOWAVE_VERSION_URL_TOKEN}/g $TEMPLATE_ROOT/bootstrap-zeppelin.sh
@@ -102,8 +108,14 @@ done
 # Copy jupyter additions to separate generated folder
 # This will put scripts into separate jupyter folder on s3 when published.
 mkdir -p $TARGET_ROOT/jupyter
+
+# copy permanent resources that don't need a template
+cp $TEMPLATE_ROOT/jupyter/install-conda.sh $TARGET_ROOT/jupyter/install-conda.sh
+cp $TEMPLATE_ROOT/jupyter/jupyterhub_config.py $TARGET_ROOT/jupyter/jupyterhub_config.py
+
 cp $TEMPLATE_ROOT/bootstrap-jupyter.sh $TARGET_ROOT/jupyter/bootstrap-jupyter.sh
 cp $TEMPLATE_ROOT/create-configure-kernel.sh $TARGET_ROOT/jupyter/create-configure-kernel.sh
+cp $TEMPLATE_ROOT/bootstrap-jupyterhub.sh $TARGET_ROOT/jupyter/bootstrap-jupyterhub.sh
 
 # Copy zeppelin additions to separate generated folder
 # This will put scripts into separate zeppelin folder on s3 when published.
@@ -116,6 +128,7 @@ rm $TEMPLATE_ROOT/bootstrap-geowave.sh
 rm $TEMPLATE_ROOT/geowave-install-lib.sh
 rm $TEMPLATE_ROOT/bootstrap-jupyter.sh
 rm $TEMPLATE_ROOT/create-configure-kernel.sh
+rm $TEMPLATE_ROOT/bootstrap-jupyterhub.sh
 rm $TEMPLATE_ROOT/bootstrap-zeppelin.sh
 rm $TEMPLATE_ROOT/configure-zeppelin.sh
 

--- a/deploy/packaging/emr/template/jupyter/bootstrap-jupyter.sh.template
+++ b/deploy/packaging/emr/template/jupyter/bootstrap-jupyter.sh.template
@@ -1,14 +1,25 @@
 #!/bin/bash
 
 GEOWAVE_VER=${1:-$GEOWAVE_VERSION_TOKEN}
-
 JUPYTER_PASSWORD=${2-geowave}
+
+is_master() {
+  if [ $(jq '.isMaster' /mnt/var/lib/info/instance.json) = 'true' ]; then
+    return 0
+  else
+    return 1
+  fi
+}
 
 # I've externalized commands into library functions for clarity, download and source
 if [ ! -f /tmp/create-configure-kernel.sh ]; then
 	aws s3 cp s3://geowave/$GEOWAVE_VERSION_URL_TOKEN/scripts/emr/jupyter/create-configure-kernel.sh /tmp/create-configure-kernel.sh
 fi
-source /tmp/create-configure-kernel.sh
+
+if [ ! -f /tmp/install-conda.sh ]; then
+	aws s3 cp s3://geowave/$GEOWAVE_VERSION_URL_TOKEN/scripts/emr/jupyter/install-conda.sh /tmp/install-conda.sh
+	sudo chmod +x /tmp/install-conda.sh
+fi
 
 # The EMR customize hooks run _before_ everything else, so Spark is not yet ready
 THIS_SCRIPT="$(realpath "${BASH_SOURCE[0]}")"
@@ -22,48 +33,20 @@ if [ ! -f "$RUN_FLAG" ]; then
 	exit 0 # Bail and let EMR finish initializing
 fi
 
-# Install conda
-wget https://repo.continuum.io/miniconda/Miniconda3-4.2.12-Linux-x86_64.sh -O $HOME/miniconda.sh
-
 # Download example notebooks from s3
-aws s3 sync s3://geowave-notebooks/$GEOWAVE_VERSION_URL_TOKEN/notebooks/ $HOME/notebooks/
+aws s3 sync s3://geowave-notebooks/latest/notebooks/ $HOME/notebooks/
 
-# Modify the file permissions to allow execution within this shell
-chmod +x $HOME/miniconda.sh
-
-# Install miniconda and output directory to ~/conda
-$HOME/miniconda.sh -b -p $HOME/conda
-
-# Add Conda to the path
-printf '\nexport PATH=$HOME/conda/bin:$PATH' >> $HOME/.bashrc
-
-# Source the new PATH
-source $HOME/.bashrc
-
-# Setup conda to use the correct channel for pixiedust prerequisites
-conda config --set always_yes yes --set changeps1 no
-conda config -f --add channels conda-forge
-
-# Install the necessary components for jupyter and pixiedust
-conda install jupyter matplotlib numpy pandas pyyaml requests shapely folium owslib
-
-# cleanup
-rm ~/miniconda.sh
+source /tmp/install-conda.sh
 
 echo bootstrap_conda.sh completed. PATH now: $PATH
 
 echo Performing pixiedust and jupyter kernel setup.
 
-# setup python 3.5 in the master and workers
-printf "\nexport PYSPARK_PYTHON=$HOME/conda/bin/python3.5" >> $HOME/.bashrc
-printf "\nexport PYSPARK_DRIVER_PYTHON=$HOME/conda/bin/python3.5" >> $HOME/.bashrc
-# This was added because Upstart doesn't capture user environment variables before loading jupyter
-printf "\nexport HOSTNAME=$HOSTNAME" >> $HOME/.bashrc
-source $HOME/.bashrc
+source /tmp/create-configure-kernel.sh $GEOWAVE_VER
 
-pip install --upgrade pip
-# Pandas added to install again because conda-forge misses correct pytz dependency version
-pip install  pixiedust ipywidgets ipyleaflet geomet pandas shapely folium owslib
+source /etc/profile.d/conda.sh
+
+conda install jupyter
 
 jupyter nbextension enable --py --sys-prefix ipyleaflet
 jupyter nbextension enable --py --sys-prefix widgetsnbextension
@@ -81,8 +64,29 @@ printf "\nc.NotebookApp.ip = '*'" >> $HOME/.jupyter/jupyter_notebook_config.py
 printf "\nc.NotebookApp.notebook_dir = '$HOME/notebooks/'" >> $HOME/.jupyter/jupyter_notebook_config.py
 printf "\nc.NotebookApp.port = 9000" >> $HOME/.jupyter/jupyter_notebook_config.py
 
-# Install Jupyter Kernel components on master node
-if is_master ; then
-	install_kernel	
-fi
+#Adding Jupyter to Upstart so it can be run at bootstrap
+cd $HOME
+sudo cat << EOF > $HOME/jupyter.conf
+description "Jupyter"
+
+start on runlevel [2345]
+stop on runlevel [016]
+
+respawn
+respawn limit 0 10
+
+env HOME=$HOME
+script
+    . $HOME/.bashrc
+    exec start-stop-daemon --start -c hadoop --exec $HOME/conda/bin/jupyter-notebook
+end script
+EOF
+sudo mv $HOME/jupyter.conf /etc/init/
+sudo chown root:root /etc/init/jupyter.conf
+
+# be sure that jupyter daemon is registered in initctl
+sudo initctl reload-configuration
+
+# start jupyter daemon
+sudo initctl start jupyter
 

--- a/deploy/packaging/emr/template/jupyter/bootstrap-jupyterhub.sh.template
+++ b/deploy/packaging/emr/template/jupyter/bootstrap-jupyterhub.sh.template
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# Variables for kernel creation
+GEOWAVE_VER=${1:-$GEOWAVE_VERSION_TOKEN}
+USER_PASS=${2:-geowave}
+
+is_master() {
+ if [ $(jq '.isMaster' /mnt/var/lib/info/instance.json) = 'true' ]; then
+  return 0
+ else
+  return 1
+ fi
+}
+
+# I've externalized commands into library functions for clarity, download and source
+if [ ! -f /tmp/create-configure-kernel.sh ]; then
+	aws s3 cp s3://geowave/$GEOWAVE_VERSION_URL_TOKEN/scripts/emr/jupyter/create-configure-kernel.sh /tmp/create-configure-kernel.sh
+	sudo chmod +x /tmp/create-configure-kernel.sh
+fi
+
+if [ ! -f /tmp/install-conda.sh ]; then
+	aws s3 cp s3://geowave/$GEOWAVE_VERSION_URL_TOKEN/scripts/emr/jupyter/install-conda.sh /tmp/install-conda.sh
+	sudo chmod +x /tmp/install-conda.sh
+fi
+
+
+# The EMR customize hooks run _before_ everything else, so Spark is not yet ready
+THIS_SCRIPT="$(realpath "${BASH_SOURCE[0]}")"
+RUN_FLAG="${THIS_SCRIPT}.run"
+# On first boot skip past this script to allow EMR to set up the environment. Set a callback
+# which will poll for availability of Spark and then create the jupyter kernel
+if [ ! -f "$RUN_FLAG" ]; then
+	touch "$RUN_FLAG"
+	TIMEOUT= is_master && TIMEOUT=3 || TIMEOUT=4
+	echo "bash -x $(realpath "${BASH_SOURCE[0]}") > /tmp/bootstrap-jupyterhub.log" | at now + $TIMEOUT min
+	exit 0 # Bail and let EMR finish initializing
+fi
+
+# Download example notebooks from s3
+aws s3 sync s3://geowave-notebooks/latest/notebooks/ $HOME/notebooks/
+
+# Download hub configuration file
+sudo su root -c "aws s3 cp s3://geowave/$GEOWAVE_VERSION_URL_TOKEN/scripts/emr/jupyter/jupyterhub_config.py /etc/jupyterhub/"
+
+# Download latest conda (Python 3.6.1) to root install location
+sudo su root -c "source /tmp/install-conda.sh /opt/miniconda.sh /opt/conda/"
+
+# Install the necessary components for jupyter and pixiedust
+sudo su root -c "/opt/conda/bin/conda install jupyterhub jupyter ncurses"
+
+echo bootstrap_conda.sh completed. PATH now: $PATH
+echo Performing pixiedust and jupyter kernel setup.
+
+if is_master; then
+	sudo su root -c "source /tmp/create-configure-kernel.sh $GEOWAVE_VER /usr/local/pixiedust /opt/conda/bin /opt/conda/share/jupyter/kernels"
+fi
+
+# Allow pixiedust to be accessed by all users
+sudo chmod -R 777 /usr/local/pixiedust/
+
+# Add upstart service to run jupyterhub
+sudo cat << EOF > $HOME/jupyterhub.conf
+description "JupyterHub"
+
+start on runlevel [2345]
+stop on runlevel [016]
+
+respawn
+respawn limit 0 10
+
+script
+   if [ -f /etc/jupyterhub/oauth_env.sh ]; then
+       . /etc/jupyterhub/oauth_env.sh
+   fi
+   . /etc/profile.d/conda.sh
+   exec start-stop-daemon --start --exec /opt/conda/bin/jupyterhub -- --config /etc/jupyterhub/jupyterhub_config.py > /var/log/jupyterhub.log 2>&1
+end script
+EOF
+sudo mv $HOME/jupyterhub.conf /etc/init/
+sudo chown root:root /etc/init/jupyterhub.conf
+
+sudo mkdir -p /srv/jupyterhub
+# Write default userlist that adds jupyterhub user as admin
+sudo cat << EOF > $HOME/userlist
+jupyterhub admin
+EOF
+sudo mv $HOME/userlist /srv/jupyterhub/
+sudo chown root:root /srv/jupyterhub/userlist
+
+# Add jupyterhub user
+sudo useradd -m -s /bin/bash -N jupyterhub
+sudo printf "jupyterhub:$USER_PASS" | sudo chpasswd
+
+# Start jupyterhub service
+# be sure that jupyter daemon is registered in initctl
+sudo initctl reload-configuration
+sudo initctl start jupyterhub

--- a/deploy/packaging/emr/template/jupyter/create-configure-kernel.sh.template
+++ b/deploy/packaging/emr/template/jupyter/create-configure-kernel.sh.template
@@ -1,18 +1,16 @@
 #!/bin/bash
 
+
 GEOWAVE_VER=${1:-$GEOWAVE_VERSION_TOKEN}
-MASTER_ARG=${2:-yarn}
+PIXIEDUST_HOME=${2:-$HOME/pixiedust/}
+CONDA_INSTALL=${3:-$HOME/conda/bin}
+KERNEL_OUT=${4:-$HOME/.local/share/jupyter/kernels/}
+SPARK_HOME=${5:-/usr/lib/spark}
+MASTER_ARG=${6:-yarn}
+
 INTIAL_POLLING_INTERVAL=15 # This gets doubled for each attempt up to max_attempts
 
-# Parses a configuration file put in place by EMR to determine the role of this node
-
-is_master() {
-  if [ $(jq '.isMaster' /mnt/var/lib/info/instance.json) = 'true' ]; then
-    return 0
-  else
-    return 1
-  fi
-}
+KERNEL_DIR=$HOME/.local/share/jupyter/kernels/
 
 # Avoid race conditions and actually poll for availability of component dependencies
 # Credit: http://stackoverflow.com/questions/8350942/how-to-re-run-the-curl-command-automatically-when-the-error-occurs/8351489#8351489
@@ -61,14 +59,17 @@ wait_until_spark_is_available() {
 	fi
 }
 
-install_kernel() {
+#Install the Kernel
 wait_until_spark_is_available
 
 # Create the jupyter kernel
-jupyter pixiedust install <<END
-y
+mkdir -p  $PIXIEDUST_HOME
+
+${CONDA_INSTALL}/jupyter pixiedust install <<END
 n
-/usr/lib/spark
+$PIXIEDUST_HOME
+n
+$SPARK_HOME
 y
 y
 y
@@ -76,9 +77,8 @@ END
 
 #Use jq to remove unnecessary keys
 GEOWAVE_INSTALL=/usr/local/geowave/tools/geowave-tools-${GEOWAVE_VER}-apache.jar
-#Grab all pixiedust kernels installed (should only be one by default), and use for master kernel changes.
-KERNEL_DIR=$HOME/.local/share/jupyter/kernels/
-PIXIEDUST_KERNELS="$(find $KERNEL_DIR -type d -name 'pythonwithpixiedustspark*')"
+PIXIEDUST_KERNELS=$(find $KERNEL_DIR -type d -name pythonwithpixiedustspark*)
+echo $PIXIEDUST_KERNELS
 KERNEL_JSON=$PIXIEDUST_KERNELS/kernel.json
 jq 'del(.env["SPARK_LOCAL_IP"])' $KERNEL_JSON > tmp.$$.json && mv tmp.$$.json $KERNEL_JSON
 jq 'del(.env["SPARK_DRIVER_MEMORY"])' $KERNEL_JSON > tmp.$$.json && mv tmp.$$.json $KERNEL_JSON
@@ -128,31 +128,5 @@ jq --arg submit_args "${submit_string}" '.env["PYSPARK_SUBMIT_ARGS"]= $submit_ar
 
 echo "Modified Kernel to use yarn by default"
 
-#Adding Jupyter to Upstart so it can be run at bootstrap
-cd $HOME
-sudo cat << EOF > $HOME/jupyter.conf
-description "Jupyter"
-
-start on runlevel [2345]
-stop on runlevel [016]
-
-respawn
-respawn limit 0 10
-
-env HOME=$HOME
-script
-    . $HOME/.bashrc
-    exec start-stop-daemon --start -c hadoop --exec $HOME/conda/bin/jupyter-notebook
-end script
-EOF
-sudo mv $HOME/jupyter.conf /etc/init/
-sudo chown root:root /etc/init/jupyter.conf
-
-# be sure that jupyter daemon is registered in initctl
-sudo initctl reload-configuration
-
-# start jupyter daemon
-sudo initctl start jupyter
-
-return 0
-}
+# Copy final modified kernel to output install location
+cp -R $PIXIEDUST_KERNELS $KERNEL_OUT

--- a/deploy/packaging/emr/template/jupyter/install-conda.sh
+++ b/deploy/packaging/emr/template/jupyter/install-conda.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+CONDA_DL_LOC=${1-$HOME/miniconda.sh}
+CONDA_INSTALL_LOC=${2-$HOME/conda/}
+
+
+# Download latest conda (Python 3.6.1) to root install location
+wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O $CONDA_DL_LOC
+
+# Modify the file permissions to allow execution within this shell
+chmod +x "$CONDA_DL_LOC"
+
+# Install miniconda and output directory to /opt/conda
+$CONDA_DL_LOC -bfp $CONDA_INSTALL_LOC
+
+# Add Conda to the path so all users with shell can see conda
+printf "export PATH=${CONDA_INSTALL_LOC}bin:"'$PATH' | sudo tee -a /etc/profile.d/conda.sh
+# setup python 3.6 in the master and workers
+printf "\nexport PYSPARK_PYTHON=${CONDA_INSTALL_LOC}bin/python3.6" | sudo tee -a /etc/profile.d/conda.sh
+printf "\nexport PYSPARK_DRIVER_PYTHON=${CONDA_INSTALL_LOC}bin/python3.6" | sudo tee -a /etc/profile.d/conda.sh
+# This was added because Upstart doesn't capture user environment variables before loading jupyter
+printf "\nexport HOSTNAME=$HOSTNAME" | sudo tee -a /etc/profile.d/conda.sh
+
+sudo chmod +x /etc/profile.d/conda.sh
+
+source /etc/profile.d/conda.sh
+
+# Set config options to install dependencies properly
+${CONDA_INSTALL_LOC}/bin/conda config --system --set always_yes yes --set changeps1 no
+${CONDA_INSTALL_LOC}/bin/conda config --system -f --add channels conda-forge
+
+# Install dependencies used for geowave + pixiedust
+${CONDA_INSTALL_LOC}/bin/conda install matplotlib numpy pandas pyyaml requests shapely folium owslib nbconvert
+
+# Install pip dependencies
+${CONDA_INSTALL_LOC}/bin/pip install pixiedust oauthenticator ipywidgets ipyleaflet geomet pandas shapely folium owslib
+
+rm $CONDA_DL_LOC

--- a/deploy/packaging/emr/template/jupyter/jupyterhub_config.py
+++ b/deploy/packaging/emr/template/jupyter/jupyterhub_config.py
@@ -1,0 +1,57 @@
+c = get_config()
+
+import os
+pjoin = os.path.join
+
+runtime_dir = pjoin('/srv/jupyterhub')
+userlist_loc = pjoin(runtime_dir, 'userlist')
+blacklist_loc = pjoin(runtime_dir, 'env_blacklist')
+ssl_dir = pjoin(runtime_dir, 'ssl')
+if not os.path.exists(ssl_dir):
+    os.makedirs(ssl_dir)
+
+# Setup whitelist and admins from file in runtime directory
+whitelist = set()
+admin = set()
+if os.path.isfile(userlist_loc):
+    with open(userlist_loc) as f:
+        for line in f:
+            if not line.strip():
+                continue
+            parts = line.split()
+            name = parts[0].strip()
+            whitelist.add(name)
+            if len(parts) > 1 and parts[1].strip() == 'admin':
+                admin.add(name)
+
+c.Authenticator.whitelist = whitelist
+c.Authenticator.admin_users = admin
+
+# Create a blacklist of environment variables to ensure are removed from notebook environments
+env_blacklist = []
+if os.path.isfile(blacklist_loc):
+    with open(blacklist_loc) as f:
+        for line in f:
+            if not line.strip():
+                continue
+            line = line.strip()
+            env_blacklist.append(line)
+
+for var in os.environ:
+    if var not in env_blacklist:
+        c.Spawner.env_keep.append(var)
+
+
+c.JupyterHub.hub_ip = '0.0.0.0'
+
+# Allow administrators to access individual user notebook servers.
+c.JupyterHub.admin_access = True
+
+# If SSL certificates exist on cluster uncomment these lines in config.
+# Will look in /srv/jupyterhub/ssl/
+#c.JupyterHub.ssl_key = pjoin(ssl_dir, 'ssl.key')
+#c.JupyterHub.ssl_cert = pjoin(ssl_dir, 'ssl.cert')
+c.JupyterHub.port = 9000
+
+# Fix adduser command so it doesn't apply invalid parameters.
+c.Authenticator.add_user_cmd = ['adduser']


### PR DESCRIPTION
Current deployment explanation:
Deployment modifies single jupyter server deployment (bootstrap-jupyter) while keeping that deployment option intact. My thought behind this was the single server deployment option still provides the quickest and easiest route for someone just trying to demo what geowave + jupyter is capable of with the least additional configuration needed. JupyterHub with GEOAxis seemed a more specific deployment route that wouldn't traditionally be used by common public users.

For JupyterHub:
Current deployment assumes GEOAxis OAuthenticator will be used along with ssl certificates. These settings are configured within the jupyterhub_config.py. JupyterHub is configured as a Upstart service and started when the bootstrapping is complete.  When JupyterHub starts it will run jupyterhub_config.py which loads ssl settings and sets up the user whitelist from files mentioned below.
Files used by the runtime configuration are expected to be located in the following directory:
`/srv/jupyterhub/`
Some examples of runtime config files would be the ssl certs and user list
`/srv/jupyterhub/ssl/ssl.key`
`/srv/jupyterhub/ssl/ssl.cert`
`/srv/jupyterhub/userlist`
`/srv/jupyterhub/env_blacklist`

Files used for configuring jupyterhub are expected to be in the following directory:
`/etc/jupyterhub/`
The jupyterhub config file will be located here, and the user is expected to put OAuth environment variables in a file here if they want the Upstart service to recognize them. `/etc/jupyterhub/oauth_env.sh`
When the Upstart service starts it will source conda + oauth dependencies to make sure they are available to the jupterhub daemon.

Questions about deployment:
1. Are we expecting to make this deployment compatible with other OAuth providers/Authenticators besides GEOAxis? i.e. github + PAM authentication?
2. If so, which OAuth providers/Authenticators should we support deployments for out of box?