### PR TITLE
Update build steps for pyspark tarball

### DIFF
--- a/deploy/packaging/docker/build-src/build-geowave-common.sh
+++ b/deploy/packaging/docker/build-src/build-geowave-common.sh
@@ -55,7 +55,8 @@ if [[ ! -f $WORKSPACE/deploy/target/puppet-scripts-${GEOWAVE_VERSION}.tar.gz ]];
 fi
 
 ## Build the pyspark module
-if [[ ! -f $WORKSPACE/analytics/pyspark/target/geowave_pyspark-${GEOWAVE_VERSION_STR}.tar.gz ]]; then
+if [[ ! -f $WORKSPACE/analytics/pyspark/target/geowave_pyspark-${GEOWAVE_VERSION}.tar.gz ]]; then
     mvn package -am -pl analytics/pyspark -Ppyspark
+    mv $WORKSPACE/analytics/pyspark/target/geowave_pyspark-${GEOWAVE_VERSION_STR}.tar.gz $WORKSPACE/analytics/pyspark/target/geowave_pyspark-${GEOWAVE_VERSION}.tar.gz
 fi
 

--- a/deploy/packaging/docker/publish/publish-common-rpm.sh
+++ b/deploy/packaging/docker/publish/publish-common-rpm.sh
@@ -73,7 +73,7 @@ if command -v aws >/dev/null 2>&1 ; then
 		aws s3 cp --acl public-read --recursive ${WORKSPACE}/examples/data/notebooks/ s3://geowave/${GEOWAVE_VERSION_URL}/notebooks/ --quiet
 
 		# Copy built pyspark package to lib directory
-		aws s3 cp --acl public-read ${WORKSPACE}/analytics/pyspark/target/geowave_pyspark-${GEOWAVE_VERSION_STR}.tar.gz s3://geowave/${GEOWAVE_VERSION_URL}/lib/geowave_pyspark-${GEOWAVE_VERSION_URL}.tar.gz
+		aws s3 cp --acl public-read ${WORKSPACE}/analytics/pyspark/target/geowave_pyspark-${GEOWAVE_VERSION}.tar.gz s3://geowave/${GEOWAVE_VERSION_URL}/lib/geowave_pyspark-${GEOWAVE_VERSION}.tar.gz
 	else
 		echo '###### Skipping publish to S3: GEOWAVE_VERSION_URL not defined'
 	fi

--- a/deploy/packaging/emr/template/jupyter/bootstrap-jupyter.sh.template
+++ b/deploy/packaging/emr/template/jupyter/bootstrap-jupyter.sh.template
@@ -36,7 +36,7 @@ fi
 # Download example notebooks from s3
 aws s3 sync s3://geowave/$GEOWAVE_VERSION_URL_TOKEN/notebooks/jupyter/ $HOME/notebooks/
 
-aws s3 cp s3://geowave/$GEOWAVE_VERSION_URL_TOKEN/lib/geowave_pyspark-$GEOWAVE_VERSION_URL_TOKEN.tar.gz /tmp/geowave_pyspark-${GEOWAVE_VER}.tar.gz
+aws s3 cp s3://geowave/$GEOWAVE_VERSION_URL_TOKEN/lib/geowave_pyspark-${GEOWAVE_VER}.tar.gz /tmp/geowave_pyspark-${GEOWAVE_VER}.tar.gz
 
 source /tmp/install-conda.sh
 

--- a/deploy/packaging/emr/template/jupyter/bootstrap-jupyterhub.sh.template
+++ b/deploy/packaging/emr/template/jupyter/bootstrap-jupyterhub.sh.template
@@ -46,9 +46,9 @@ sudo su root -c "aws s3 cp s3://geowave/$GEOWAVE_VERSION_URL_TOKEN/scripts/emr/j
 sudo su root -c "source /tmp/install-conda.sh /opt/miniconda.sh /opt/conda/"
 
 # Install the necessary components for jupyter and pixiedust
-sudo su root -c "/opt/conda/bin/conda install jupyterhub jupyter ncurses"
+sudo su root -c "/opt/conda/bin/conda install jupyterhub=0.9.1 jupyter ncurses"
 
-sudo su root -c "aws s3 cp s3://geowave/$GEOWAVE_VERSION_URL_TOKEN/lib/geowave_pyspark-$GEOWAVE_VERSION_URL_TOKEN.tar.gz /tmp/geowave_pyspark-${GEOWAVE_VER}.tar.gz"
+sudo su root -c "aws s3 cp s3://geowave/$GEOWAVE_VERSION_URL_TOKEN/lib/geowave_pyspark-${GEOWAVE_VER}.tar.gz /tmp/geowave_pyspark-${GEOWAVE_VER}.tar.gz"
 
 sudo su root -c "/opt/conda/bin/pip install /tmp/geowave_pyspark-${GEOWAVE_VER}.tar.gz"
 

--- a/deploy/packaging/emr/template/jupyter/install-conda.sh
+++ b/deploy/packaging/emr/template/jupyter/install-conda.sh
@@ -33,6 +33,6 @@ ${CONDA_INSTALL_LOC}/bin/conda config --system -f --add channels conda-forge
 ${CONDA_INSTALL_LOC}/bin/conda install matplotlib numpy pandas pyyaml requests shapely folium owslib nbconvert
 
 # Install pip dependencies
-${CONDA_INSTALL_LOC}/bin/pip install pixiedust oauthenticator ipywidgets ipyleaflet geomet pandas shapely folium owslib
+${CONDA_INSTALL_LOC}/bin/pip install pixiedust oauthenticator==0.7.3 ipywidgets ipyleaflet geomet pandas shapely folium owslib
 
 rm -f ${CONDA_DL_LOC}


### PR DESCRIPTION
Also locks down versions of jupyterhub + oauthenticator.
If we want to lockdown all versions of python dependencies according to submitted swap requests. I can modify how python dependencies are installed to be more robust. I can create a `requirements.txt` file for python dependencies, which will be locked down to specific dependency versions and have each bootstrap install from that file. I just need to know all versions of python dependencies that were swap approved.