### PR TITLE
Change publish scripts to use geowave-notebooks

### DIFF
--- a/deploy/packaging/docker/publish/publish-common-rpm.sh
+++ b/deploy/packaging/docker/publish/publish-common-rpm.sh
@@ -70,7 +70,7 @@ if command -v aws >/dev/null 2>&1 ; then
 		aws s3 cp --acl public-read --recursive ${WORKSPACE}/deploy/packaging/emr/generated/ s3://geowave/${GEOWAVE_VERSION_URL}/scripts/emr/ --quiet
 		aws s3 cp --acl public-read --recursive ${WORKSPACE}/deploy/packaging/sandbox/generated/ s3://geowave/${GEOWAVE_VERSION_URL}/scripts/sandbox/ --quiet
 
-		aws s3 cp --acl public-read --recursive ${WORKSPACE}/examples/data/notebooks/ s3://geowave/${GEOWAVE_VERSION_URL}/notebooks/ --quiet
+		aws s3 cp --acl public-read --recursive ${WORKSPACE}/examples/data/notebooks/ s3://geowave-notebooks/${GEOWAVE_VERSION_URL}/notebooks/ --quiet
 
 		# Copy built pyspark package to lib directory
 		aws s3 cp --acl public-read ${WORKSPACE}/analytics/pyspark/target/geowave_pyspark-${GEOWAVE_VERSION}.tar.gz s3://geowave/${GEOWAVE_VERSION_URL}/lib/geowave_pyspark-${GEOWAVE_VERSION}.tar.gz

--- a/deploy/packaging/emr/template/jupyter/bootstrap-jupyter.sh.template
+++ b/deploy/packaging/emr/template/jupyter/bootstrap-jupyter.sh.template
@@ -34,7 +34,7 @@ if [ ! -f "$RUN_FLAG" ]; then
 fi
 
 # Download example notebooks from s3
-aws s3 sync s3://geowave/$GEOWAVE_VERSION_URL_TOKEN/notebooks/jupyter/ $HOME/notebooks/
+aws s3 sync s3://geowave-notebooks/$GEOWAVE_VERSION_URL_TOKEN/notebooks/jupyter/ $HOME/notebooks/
 
 aws s3 cp s3://geowave/$GEOWAVE_VERSION_URL_TOKEN/lib/geowave_pyspark-${GEOWAVE_VER}.tar.gz /tmp/geowave_pyspark-${GEOWAVE_VER}.tar.gz
 

--- a/deploy/packaging/emr/template/jupyter/bootstrap-jupyterhub.sh.template
+++ b/deploy/packaging/emr/template/jupyter/bootstrap-jupyterhub.sh.template
@@ -37,7 +37,7 @@ if [ ! -f "$RUN_FLAG" ]; then
 fi
 
 # Download example notebooks from s3
-aws s3 sync s3://geowave/latest/notebooks/jupyter $HOME/notebooks/
+aws s3 sync s3://geowave-notebooks/$GEOWAVE_VERSION_URL_TOKEN/notebooks/jupyter/ $HOME/notebooks/
 
 # Download hub configuration file
 sudo su root -c "aws s3 cp s3://geowave/$GEOWAVE_VERSION_URL_TOKEN/scripts/emr/jupyter/jupyterhub_config.py /etc/jupyterhub/"


### PR DESCRIPTION
Band-aid solution to not being able to recursive copy from 'geowave/latest'. 
Long-term solution involving creating separate geowave-docs bucket outlined in scrumdo ticket: [G3-458](https://app.scrumdo.com/projects/story_permalink/1664464)