### PR TITLE
Bugfix: fixes typo by adding missing comma.

### DIFF
--- a/deploy/packaging/puppet/geowave/manifests/init.pp
+++ b/deploy/packaging/puppet/geowave/manifests/init.pp
@@ -5,7 +5,7 @@ class geowave(
   $install_hbase          = $geowave::params::install_hbase,
   $install_app            = $geowave::params::install_app,
   $install_gwgeoserver    = $geowave::params::install_gwgeoserver,
-  $install_gwgrpc         = $geowave::params::install_gwgrpc
+  $install_gwgrpc         = $geowave::params::install_gwgrpc,
   $install_restservices   = $geowave::params::install_restservices,
   $http_port              = $geowave::params::http_port,
   $ajp_port               = $geowave::params::ajp_port_ajp,


### PR DESCRIPTION
This should clear up the error during EMR provisioning.