### PR TITLE
Updating spatial join test and pyspark module settings

### DIFF
--- a/analytics/pom.xml
+++ b/analytics/pom.xml
@@ -14,13 +14,6 @@
 		<module>api</module>
 		<module>spark</module>
 		<module>mapreduce</module>
+		<module>pyspark</module>
 	</modules>
-	<profiles>
-		<profile>
-			<id>pyspark</id>
-			<modules>
-				<module>pyspark</module>
-			</modules>
-		</profile>
-	</profiles>
 </project>

--- a/analytics/pyspark/pom.xml
+++ b/analytics/pyspark/pom.xml
@@ -42,10 +42,18 @@
                     </execution>
                 </executions>
             </plugin>
+            </plugins>
+        </build>
 
+    <profiles>
+    <profile>
+    <id>python</id>
+    <build>
+        <plugins>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
                 <configuration>
                     <executable>${python.executable}</executable>
                 </configuration>
@@ -90,4 +98,7 @@
             </plugin>
         </plugins>
     </build>
+    </profile>
+    </profiles>
+
 </project>


### PR DESCRIPTION
Spatial join test is now correctly pulling from two stores instead of one.
Pyspark module is always included in project/build, but python package only built if python profile is attached.