### PR TITLE
Spark commands and related grpc IT refactoring

### DIFF
--- a/analytics/spark/src/main/java/org/locationtech/geowave/analytic/spark/kmeans/KMeansRunner.java
+++ b/analytics/spark/src/main/java/org/locationtech/geowave/analytic/spark/kmeans/KMeansRunner.java
@@ -221,15 +221,15 @@ public class KMeansRunner
 		kmeansOpts.setMaxSplits(maxSplits);
 		kmeansOpts.setQuery(query);
 		kmeansOpts.setQueryOptions(queryOptions);
-		
-		LOGGER.debug("Loading RDD from datastore...");
+
+		LOGGER.warn("Loading RDD from datastore...");
 		GeoWaveRDD kmeansRDD = GeoWaveRDDLoader.loadRDD(
 				session.sparkContext(),
 				inputDataStore,
 				kmeansOpts);
 
 		// Retrieve the input centroids
-		LOGGER.debug("Retrieving input centroids from RDD...");
+		LOGGER.warn("Retrieving input centroids from RDD...");
 		centroidVectors = RDDUtils.rddFeatureVectors(
 				kmeansRDD,
 				timeField,
@@ -247,24 +247,27 @@ public class KMeansRunner
 		}
 
 		// Run KMeans
-		LOGGER.debug("Running KMeans algorithm...");
+		LOGGER.warn("Running KMeans algorithm...");
 		outputModel = kmeans.run(centroidVectors.rdd());
 
-		LOGGER.debug("Writing results to output store...");
+		LOGGER.warn("Writing results to output store...");
 		writeToOutputStore();
-		LOGGER.debug("Results successfully written!");
+		LOGGER.warn("Results successfully written!");
 	}
 
 	public void writeToOutputStore() {
 		if (outputDataStore != null) {
 			// output cluster centroids (and hulls) to output datastore
+			LOGGER.warn("Outputting cluster centroids...");
 			KMeansUtils.writeClusterCentroids(
 					outputModel,
 					outputDataStore,
 					centroidTypeName,
 					scaledRange);
 
-			if (isGenerateHulls()) {
+			if (isGenerateHulls()) 
+			{
+				LOGGER.warn("Outputting cluster hulls...");
 				KMeansUtils.writeClusterHulls(
 						centroidVectors,
 						outputModel,

--- a/analytics/spark/src/main/java/org/locationtech/geowave/analytic/spark/kmeans/KMeansRunner.java
+++ b/analytics/spark/src/main/java/org/locationtech/geowave/analytic/spark/kmeans/KMeansRunner.java
@@ -87,7 +87,7 @@ public class KMeansRunner
 	public KMeansRunner() {}
 
 	private void initContext() {
-		if (jsc == null) {
+		if (session == null) {
 			String jar = "";
 			try {
 				jar = KMeansRunner.class.getProtectionDomain().getCodeSource().getLocation().toURI().getPath();
@@ -109,11 +109,6 @@ public class KMeansRunner
 	}
 
 	public void close() {
-		if (jsc != null) {
-			jsc.close();
-			jsc = null;
-		}
-
 		if (session != null) {
 			session.close();
 			session = null;
@@ -226,12 +221,15 @@ public class KMeansRunner
 		kmeansOpts.setMaxSplits(maxSplits);
 		kmeansOpts.setQuery(query);
 		kmeansOpts.setQueryOptions(queryOptions);
+		
+		LOGGER.debug("Loading RDD from datastore...");
 		GeoWaveRDD kmeansRDD = GeoWaveRDDLoader.loadRDD(
-				jsc.sc(),
+				session.sparkContext(),
 				inputDataStore,
 				kmeansOpts);
 
 		// Retrieve the input centroids
+		LOGGER.debug("Retrieving input centroids from RDD...");
 		centroidVectors = RDDUtils.rddFeatureVectors(
 				kmeansRDD,
 				timeField,
@@ -249,9 +247,12 @@ public class KMeansRunner
 		}
 
 		// Run KMeans
+		LOGGER.debug("Running KMeans algorithm...");
 		outputModel = kmeans.run(centroidVectors.rdd());
 
+		LOGGER.debug("Writing results to output store...");
 		writeToOutputStore();
+		LOGGER.debug("Results successfully written!");
 	}
 
 	public void writeToOutputStore() {
@@ -341,9 +342,9 @@ public class KMeansRunner
 		this.outputDataStore = outputDataStore;
 	}
 
-	public void setJavaSparkContext(
-			final JavaSparkContext jsc ) {
-		this.jsc = jsc;
+	public void setSparkSession(
+			final SparkSession ss ) {
+		this.session = ss;
 	}
 
 	public void setNumClusters(

--- a/analytics/spark/src/main/java/org/locationtech/geowave/analytic/spark/kmeans/operations/KmeansSparkCommand.java
+++ b/analytics/spark/src/main/java/org/locationtech/geowave/analytic/spark/kmeans/operations/KmeansSparkCommand.java
@@ -137,11 +137,13 @@ public class KmeansSparkCommand extends
 		runner.setOutputDataStore(outputDataStore);
 		try {
 			runner.run();
-
 		}
 		catch (final IOException e) {
 			throw new RuntimeException(
 					"Failed to execute: " + e.getMessage());
+		}
+		finally {
+			runner.close();
 		}
 
 		return null;

--- a/analytics/spark/src/main/java/org/locationtech/geowave/analytic/spark/sparksql/operations/SparkSqlCommand.java
+++ b/analytics/spark/src/main/java/org/locationtech/geowave/analytic/spark/sparksql/operations/SparkSqlCommand.java
@@ -148,6 +148,7 @@ public class SparkSqlCommand extends
 					sparkSqlOptions.getCsvOutputFile());
 
 		}
+		sqlRunner.close();
 		return null;
 	}
 

--- a/analytics/spark/src/main/java/org/locationtech/geowave/analytic/spark/spatial/SpatialJoinRunner.java
+++ b/analytics/spark/src/main/java/org/locationtech/geowave/analytic/spark/spatial/SpatialJoinRunner.java
@@ -122,6 +122,13 @@ public class SpatialJoinRunner implements
 		writeResultsToNewAdapter();
 	}
 
+	public void close() {
+		if (session != null) {
+			session.close();
+			session = null;
+		}
+	}
+
 	private PrimaryIndex[] getIndicesForAdapter(
 			DataStorePluginOptions storeOptions,
 			ByteArrayId adapterId,

--- a/analytics/spark/src/main/java/org/locationtech/geowave/analytic/spark/spatial/operations/SpatialJoinCommand.java
+++ b/analytics/spark/src/main/java/org/locationtech/geowave/analytic/spark/spatial/operations/SpatialJoinCommand.java
@@ -154,7 +154,7 @@ public class SpatialJoinCommand extends
 
 		// Finally call run to execute the join
 		runner.run();
-
+		runner.close();
 		return null;
 	}
 

--- a/examples/data/notebooks/jupyter/geowave-gdelt.ipynb
+++ b/examples/data/notebooks/jupyter/geowave-gdelt.ipynb
@@ -23,9 +23,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import pixiedust\n",
@@ -199,7 +197,7 @@
    "outputs": [],
    "source": [
     "#Set the appropriate properties\n",
-    "kmeans_runner.setJavaSparkContext(sc._jsc)\n",
+    "kmeans_runner.setSparkSession(sc._jsparkSession)\n",
     "\n",
     "kmeans_runner.setAdapterId('gdeltevent')\n",
     "kmeans_runner.setInputDataStore(input_store_plugin)\n",
@@ -223,23 +221,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pixiedust": {
-     "displayParams": {
-      "aggregation": "SUM",
-      "chartsize": "79",
-      "googlemapapikey": "AIzaSyB4mc1rBqh0TOCcdDtzM4l5RvVE7fJqs7Q",
-      "handlerId": "tableView",
-      "keyFields": "geom",
-      "mapDisplayMode": "region",
-      "mapRegion": "world",
-      "rendererId": "google",
-      "rowCount": "500",
-      "title": "Centroids",
-      "valueFields": "ClusterIndex"
-     }
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Create the dataframe and get a rdd for the output of kmeans\n",
@@ -284,24 +266,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pixiedust": {
-     "displayParams": {
-      "aggregation": "SUM",
-      "chartsize": "80",
-      "coloropacity": "90",
-      "googlemapapikey": "AIzaSyANKvC0DJGY_O-I9lsRJbjUg3upoGUZvJg\\t",
-      "handlerId": "mapView",
-      "keyFields": "lat,lon",
-      "mapDisplayMode": "region",
-      "mapboxtoken": "pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpejY4M29iazA2Z2gycXA4N2pmbDZmangifQ.-g_vE53SD2WrJ6tFX7QHmA",
-      "rendererId": "mapbox",
-      "rowCount": "500",
-      "valueFields": "ClusterIndex"
-     }
-    },
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Convert the string point information into lat long columns and create a new dataframe for those.\n",
@@ -335,13 +300,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pixiedust": {
-     "displayParams": {
-      "handlerId": "tableView"
-     }
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Create the dataframe and get a rdd for the output of kmeans\n",
@@ -385,18 +344,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pixiedust": {
-     "displayParams": {
-      "aggregation": "SUM",
-      "handlerId": "dataframe",
-      "keyFields": "Count",
-      "rendererId": "google",
-      "rowCount": "500",
-      "valueFields": "Density"
-     }
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%bash\n",
@@ -431,20 +379,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pixiedust": {
-     "displayParams": {
-      "aggregation": "SUM",
-      "handlerId": "dataframe",
-      "keyFields": "Count",
-      "legend": "true",
-      "mpld3": "true",
-      "rowCount": "500",
-      "sortby": "Keys ASC",
-      "valueFields": "Density"
-     }
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import folium\n",
@@ -495,7 +430,9 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    ""
+   ]
   }
  ],
  "metadata": {
@@ -507,7 +444,7 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 3.0
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",

--- a/examples/data/notebooks/jupyter/geowave-gpx.ipynb
+++ b/examples/data/notebooks/jupyter/geowave-gpx.ipynb
@@ -66,9 +66,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Print Spark info and create sql_context\n",
@@ -94,7 +92,7 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "s3-dist-cp -D mapreduce.task.timeout=60000000 --src=s3://geowave-gpx-data/gpx --dest=hdfs://$HOSTNAME:8020/tmp/ "
+    "s3-dist-cp -D mapreduce.task.timeout=60000000 --src=s3://geowave-gpx-data/gpx --dest=hdfs://$HOSTNAME:8020/tmp/"
    ]
   },
   {
@@ -212,7 +210,7 @@
    "source": [
     "#set the appropriate properties\n",
     "#We want it to execute using the existing JavaSparkContext wrapped by python.\n",
-    "kmeans_runner.setJavaSparkContext(sc._jsc)\n",
+    "kmeans_runner.setSparkSession(sc._jsparkSession)\n",
     "\n",
     "kmeans_runner.setAdapterId('gpxpoint')\n",
     "kmeans_runner.setNumClusters(8)\n",
@@ -237,13 +235,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pixiedust": {
-     "displayParams": {
-      "handlerId": "tableView"
-     }
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Create the dataframe and get a rdd for the output of kmeans\n",
@@ -289,20 +281,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pixiedust": {
-     "displayParams": {
-      "coloropacity": "89",
-      "handlerId": "mapView",
-      "keyFields": "lat,lon",
-      "mapboxtoken": "pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpejY4M29iazA2Z2gycXA4N2pmbDZmangifQ.-g_vE53SD2WrJ6tFX7QHmA",
-      "rowCount": "500",
-      "title": "Centroids",
-      "valueFields": "ClusterIndex"
-     }
-    },
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Convert the string point information into lat long columns and create a new dataframe for those.\n",
@@ -336,13 +315,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pixiedust": {
-     "displayParams": {
-      "handlerId": "tableView"
-     }
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Create the dataframe and get a rdd for the output of kmeans\n",
@@ -471,7 +444,9 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    ""
+   ]
   }
  ],
  "metadata": {
@@ -483,7 +458,7 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 3.0
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",

--- a/test/src/main/java/org/locationtech/geowave/test/HBaseMiniClusterClassLoader.java
+++ b/test/src/main/java/org/locationtech/geowave/test/HBaseMiniClusterClassLoader.java
@@ -31,6 +31,7 @@ public class HBaseMiniClusterClassLoader extends
 	private static final String[] CLASS_PREFIX_EXEMPTIONS = new String[] {
 		// Java standard library:
 		"com.sun.",
+		"sun.",
 		"java.",
 		"javax.",
 		"org.ietf",

--- a/test/src/main/java/org/locationtech/geowave/test/services/grpc/GeoWaveGrpcTestClient.java
+++ b/test/src/main/java/org/locationtech/geowave/test/services/grpc/GeoWaveGrpcTestClient.java
@@ -446,18 +446,31 @@ public class GeoWaveGrpcTestClient
 	public boolean nearestNeighborCommand() {
 		ArrayList<String> adapters = new ArrayList<String>();
 		adapters.add(GeoWaveGrpcTestUtils.adapterId);
-		NearestNeighborCommandParameters request = NearestNeighborCommandParameters.newBuilder().addParameters(
-				GeoWaveGrpcTestUtils.storeName).addAllAdapterIds(
-				adapters).setExtractQuery(
-				GeoWaveGrpcTestUtils.wktSpatialQuery).setExtractMinInputSplit(
-				"2").setExtractMaxInputSplit(
-				"6").setPartitionMaxDistance(
-				"10").setOutputReducerCount(
-				"4").setMapReduceHdfsHostPort(
-				GeoWaveGrpcTestUtils.getMapReduceTestEnv().getHdfs()).setMapReduceJobtrackerHostPort(
-				GeoWaveGrpcTestUtils.getMapReduceTestEnv().getJobtracker()).setOutputHdfsOutputPath(
-				GeoWaveGrpcTestUtils.getMapReduceTestEnv().getHdfsBaseDirectory() + "/GrpcNearestNeighbor").setMapReduceHdfsBaseDir(
-				GeoWaveGrpcTestUtils.getMapReduceTestEnv().getHdfsBaseDirectory()).build();
+		NearestNeighborCommandParameters request = NearestNeighborCommandParameters
+				.newBuilder()
+				.addParameters(
+						GeoWaveGrpcTestUtils.storeName)
+				.addAllAdapterIds(
+						adapters)
+				.setExtractQuery(
+						GeoWaveGrpcTestUtils.wktSpatialQuery)
+				.setExtractMinInputSplit(
+						"2")
+				.setExtractMaxInputSplit(
+						"6")
+				.setPartitionMaxDistance(
+						"10")
+				.setOutputReducerCount(
+						"4")
+				.setMapReduceHdfsHostPort(
+						GeoWaveGrpcTestUtils.getMapReduceTestEnv().getHdfs())
+				.setMapReduceJobtrackerHostPort(
+						GeoWaveGrpcTestUtils.getMapReduceTestEnv().getJobtracker())
+				.setOutputHdfsOutputPath(
+						GeoWaveGrpcTestUtils.getMapReduceTestEnv().getHdfsBaseDirectory() + "/GrpcNearestNeighbor")
+				.setMapReduceHdfsBaseDir(
+						GeoWaveGrpcTestUtils.getMapReduceTestEnv().getHdfsBaseDirectory())
+				.build();
 		analyticMapreduceBlockingStub.nearestNeighborCommand(request);
 		return true;
 	}

--- a/test/src/main/java/org/locationtech/geowave/test/services/grpc/GeoWaveGrpcTestClient.java
+++ b/test/src/main/java/org/locationtech/geowave/test/services/grpc/GeoWaveGrpcTestClient.java
@@ -456,7 +456,7 @@ public class GeoWaveGrpcTestClient
 				"4").setMapReduceHdfsHostPort(
 				GeoWaveGrpcTestUtils.getMapReduceTestEnv().getHdfs()).setMapReduceJobtrackerHostPort(
 				GeoWaveGrpcTestUtils.getMapReduceTestEnv().getJobtracker()).setOutputHdfsOutputPath(
-				GeoWaveGrpcTestUtils.getMapReduceTestEnv().getHdfsBaseDirectory() + "_out").setMapReduceHdfsBaseDir(
+				GeoWaveGrpcTestUtils.getMapReduceTestEnv().getHdfsBaseDirectory() + "/GrpcNearestNeighbor").setMapReduceHdfsBaseDir(
 				GeoWaveGrpcTestUtils.getMapReduceTestEnv().getHdfsBaseDirectory()).build();
 		analyticMapreduceBlockingStub.nearestNeighborCommand(request);
 		return true;
@@ -1038,7 +1038,7 @@ public class GeoWaveGrpcTestClient
 				extensions).setFormats(
 				"gpx").setAppName(
 				"CoreGeoWaveSparkITs").setMaster(
-				"local").setHost(
+				"local[*]").setHost(
 				"localhost").setNumExecutors(
 				1).setNumCores(
 				1).build();
@@ -1159,7 +1159,7 @@ public class GeoWaveGrpcTestClient
 						true)
 				// optional
 				.setCqlFilter(
-						"none")
+						GeoWaveGrpcTestUtils.cqlSpatialQuery)
 				.setMinSplits(
 						1)
 				.setMaxSplits(

--- a/test/src/main/java/org/locationtech/geowave/test/spark/SparkTestEnvironment.java
+++ b/test/src/main/java/org/locationtech/geowave/test/spark/SparkTestEnvironment.java
@@ -26,7 +26,6 @@ public class SparkTestEnvironment implements
 
 	private static SparkTestEnvironment singletonInstance = null;
 	protected SparkSession defaultSession = null;
-	protected SparkContext defaultContext = null;
 
 	public static synchronized SparkTestEnvironment getInstance() {
 		if (singletonInstance == null) {
@@ -47,7 +46,6 @@ public class SparkTestEnvironment implements
 				LOGGER.error("Unable to create default spark session for tests");
 				return;
 			}
-			defaultContext = defaultSession.sparkContext();
 		}
 	}
 
@@ -55,7 +53,6 @@ public class SparkTestEnvironment implements
 	public void tearDown()
 			throws Exception {
 		if (defaultSession != null) {
-			defaultContext = null;
 			defaultSession.close();
 			defaultSession = null;
 		}
@@ -69,9 +66,4 @@ public class SparkTestEnvironment implements
 	public SparkSession getDefaultSession() {
 		return defaultSession;
 	}
-
-	public SparkContext getDefaultContext() {
-		return defaultContext;
-	}
-
 }

--- a/test/src/test/java/org/locationtech/geowave/test/services/grpc/GeoWaveGrpcIT.java
+++ b/test/src/test/java/org/locationtech/geowave/test/services/grpc/GeoWaveGrpcIT.java
@@ -14,7 +14,6 @@ import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.text.ParseException;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 import org.apache.log4j.Level;
@@ -55,7 +54,6 @@ import org.slf4j.LoggerFactory;
 @Environments({
 	Environment.MAP_REDUCE,
 	Environment.KAFKA,
-	Environment.SPARK
 })
 @GeoWaveTestStore(value = {
 	GeoWaveStoreType.ACCUMULO,
@@ -69,7 +67,6 @@ public class GeoWaveGrpcIT extends
 {
 	private final static Logger LOGGER = LoggerFactory.getLogger(GeoWaveGrpcIT.class);
 	private static File configFile = null;
-	private static GeoWaveGrpcServer server = null;
 	private static GeoWaveGrpcTestClient client = null;
 
 	protected DataStorePluginOptions dataStore;
@@ -503,7 +500,6 @@ public class GeoWaveGrpcIT extends
 		grpcCmdOpts.setNonBlocking(true);
 		startCmd.setCommandOptions(grpcCmdOpts);
 		startCmd.execute(operationParams);
-		server = GeoWaveGrpcServer.getInstance();
 
 		// fire up the client
 		client = new GeoWaveGrpcTestClient(

--- a/test/src/test/java/org/locationtech/geowave/test/spark/GeoWaveJavaSparkIT.java
+++ b/test/src/test/java/org/locationtech/geowave/test/spark/GeoWaveJavaSparkIT.java
@@ -101,7 +101,7 @@ public class GeoWaveJavaSparkIT extends
 	public void testLoadRDD()
 			throws Exception {
 		// Set up Spark
-		SparkContext context = SparkTestEnvironment.getInstance().getDefaultContext();
+		SparkContext context = SparkTestEnvironment.getInstance().getDefaultSession().sparkContext();
 
 		// ingest test points
 		TestUtils.testLocalIngest(

--- a/test/src/test/java/org/locationtech/geowave/test/spark/GeoWaveJavaSparkKMeansIT.java
+++ b/test/src/test/java/org/locationtech/geowave/test/spark/GeoWaveJavaSparkKMeansIT.java
@@ -100,7 +100,6 @@ public class GeoWaveJavaSparkKMeansIT
 	@Test
 	public void testKMeansRunner()
 			throws Exception {
-		SparkContext context = SparkTestEnvironment.getInstance().getDefaultContext();
 
 		// Load data
 		TestUtils.testLocalIngest(
@@ -114,7 +113,7 @@ public class GeoWaveJavaSparkKMeansIT
 		// Create the runner
 		long mark = System.currentTimeMillis();
 		final KMeansRunner runner = new KMeansRunner();
-		runner.setJavaSparkContext(JavaSparkContext.fromSparkContext(context));
+		runner.setSparkSession(SparkTestEnvironment.getInstance().defaultSession);
 		runner.setInputDataStore(inputDataStore);
 		runner.setAdapterId(adapterId);
 		runner.setCqlFilter(CQL_FILTER);

--- a/test/src/test/java/org/locationtech/geowave/test/spark/GeoWaveJavaSparkSQLIT.java
+++ b/test/src/test/java/org/locationtech/geowave/test/spark/GeoWaveJavaSparkSQLIT.java
@@ -90,8 +90,8 @@ public class GeoWaveJavaSparkSQLIT extends
 	public void testCreateDataFrame()
 			throws Exception {
 		// Set up Spark
-		SparkContext context = SparkTestEnvironment.getInstance().getDefaultContext();
 		SparkSession session = SparkTestEnvironment.getInstance().getDefaultSession();
+		SparkContext context = session.sparkContext();
 
 		// ingest test points
 		TestUtils.testLocalIngest(

--- a/test/src/test/java/org/locationtech/geowave/test/spark/GeoWaveSparkSpatialJoinIT.java
+++ b/test/src/test/java/org/locationtech/geowave/test/spark/GeoWaveSparkSpatialJoinIT.java
@@ -102,7 +102,7 @@ public class GeoWaveSparkSpatialJoinIT extends
 			throws Exception {
 
 		session = SparkTestEnvironment.getInstance().getDefaultSession();
-		context = SparkTestEnvironment.getInstance().getDefaultContext();
+		context = session.sparkContext();
 		GeomFunctionRegistry.registerGeometryFunctions(session);
 		LOGGER.debug("Testing DataStore Type: " + dataStore.getType());
 		long mark = System.currentTimeMillis();


### PR DESCRIPTION
This PR mainly addresses the fact that Spark Cli commands in the past did not properly release resources (sessions) after completion. This affected certain gRPC ITs that exercised these commands. Certain aspects of GeoWave's Spark usage have also been refactored to more accurately reflect proper usage with the Spark 2.x API.