### PR TITLE
Solved a bug in ZOrderSFC.getRange and add ZOrderSFCTest

### DIFF
--- a/core/index/src/main/java/org/locationtech/geowave/core/index/sfc/zorder/ZOrderUtils.java
+++ b/core/index/src/main/java/org/locationtech/geowave/core/index/sfc/zorder/ZOrderUtils.java
@@ -24,16 +24,19 @@ public class ZOrderUtils {
       final SFCDimensionDefinition[] dimensionDefinitions) {
     final byte[] littleEndianBytes = swapEndianFormat(bytes);
     final BitSet bitSet = BitSet.valueOf(littleEndianBytes);
+    final int usedBits = bitsPerDimension * dimensionDefinitions.length;
+    final int bitsLength = bytes.length * 8;
+    final int bitOffset = bitsLength - usedBits;
     final NumericRange[] normalizedValues = new NumericRange[dimensionDefinitions.length];
     for (int d = 0; d < dimensionDefinitions.length; d++) {
       final BitSet dimensionSet = new BitSet();
       int j = 0;
-      for (int i = d; i < (bitsPerDimension * dimensionDefinitions.length); i +=
-          dimensionDefinitions.length) {
+      for (int i = bitOffset + d; i < bitsLength; i += dimensionDefinitions.length) {
         dimensionSet.set(j++, bitSet.get(i));
       }
 
-      normalizedValues[d] = decode(dimensionSet, 0, 1, dimensionDefinitions[d]);
+      normalizedValues[d] = decode(dimensionSet, bitsPerDimension,0, 1,
+              dimensionDefinitions[d]);
     }
 
     return normalizedValues;
@@ -77,11 +80,12 @@ public class ZOrderUtils {
 
   private static NumericRange decode(
       final BitSet bs,
+      final int bitsPerDimension,
       double floor,
       double ceiling,
       final SFCDimensionDefinition dimensionDefinition) {
     double mid = 0;
-    for (int i = 0; i < bs.length(); i++) {
+    for (int i = 0; i < bitsPerDimension; i++) {
       mid = (floor + ceiling) / 2;
       if (bs.get(i)) {
         floor = mid;

--- a/core/index/src/test/java/org/locationtech/geowave/core/index/sfc/zorder/ZOrderSFCTest.java
+++ b/core/index/src/test/java/org/locationtech/geowave/core/index/sfc/zorder/ZOrderSFCTest.java
@@ -8,7 +8,40 @@
  */
 package org.locationtech.geowave.core.index.sfc.zorder;
 
+import org.junit.Assert;
+import org.junit.Test;
+import org.locationtech.geowave.core.index.dimension.BasicDimensionDefinition;
+import org.locationtech.geowave.core.index.sfc.SFCDimensionDefinition;
+import org.locationtech.geowave.core.index.sfc.data.MultiDimensionalNumericData;
+import org.locationtech.geowave.core.index.sfc.data.NumericData;
+import org.locationtech.geowave.core.index.sfc.data.NumericRange;
+
 public class ZOrderSFCTest {
 
-  // TODO: add unit tests for ZOrder implementation
+    @Test
+    public void testIndex() {
+        double[] latLngValues = new double[] {45.D, 22.D};
+        Assert.assertArrayEquals(new byte[] {12}, createSFC().getId(latLngValues));
+    }
+
+    @Test
+    public void testGetRanges() {
+        double[] latLngValues = new double[] {45.D, 22.D};
+        byte[] index = createSFC().getId(latLngValues);
+        MultiDimensionalNumericData ranges = createSFC().getRanges(index);
+        NumericData[] data = ranges.getDataPerDimension();
+        NumericData[] actualDate = new NumericRange[] {
+                new NumericRange(0.0, 90.0),
+                new NumericRange(0.0, 45.0)
+        };
+        Assert.assertArrayEquals(data, actualDate);
+    }
+
+    private ZOrderSFC createSFC() {
+        SFCDimensionDefinition[] dimensions =
+                {
+                        new SFCDimensionDefinition(new BasicDimensionDefinition(-180.0, 180.0), 2),
+                        new SFCDimensionDefinition(new BasicDimensionDefinition(-90.0, 90.0), 2)};
+        return new ZOrderSFC(dimensions);
+    }
 }


### PR DESCRIPTION
Hi!
I found that the *getRanges* function of class *ZOrderSFC* has a bug. In the original code, the return value of the function is always constant, which is the maximum and minimum of each dimension. For example, when I encode latitude and longitude, its return value is always [[-180.0, 180.0], [-90.0, 90.0]].

This bug is caused by the *decodeRanges* function and the *decode* function of the class *ZOrderUtils*. I have solved this bug and added test code for the class *ZOrderSFC*.