### PR TITLE
Bugfix/rocksdbclient close fix

### DIFF
--- a/extensions/datastores/rocksdb/src/main/java/org/locationtech/geowave/datastore/rocksdb/util/RocksDBClient.java
+++ b/extensions/datastores/rocksdb/src/main/java/org/locationtech/geowave/datastore/rocksdb/util/RocksDBClient.java
@@ -295,7 +295,10 @@ public class RocksDBClient implements Closeable {
     final String prefix = RocksDBUtils.getTablePrefix(typeName, indexName);
     for (final Entry<String, CacheKey> e : keyCache.asMap().entrySet()) {
       final String key = e.getKey();
-      if (key.substring(subDirectory.length()).startsWith(prefix)) {
+      // BUGFIX: This string compare was failing due to a separator in the file path
+      // It seems like 'contains' is a better choice, but alternately could fix like this:
+      // if (key.substring(subDirectory.length()+1).startsWith(prefix)) {
+      if (key.contains(prefix)) {
         keyCache.invalidate(key);
         AbstractRocksDBTable indexTable = indexTableCache.getIfPresent(e.getValue());
         if (indexTable == null) {

--- a/extensions/datastores/rocksdb/src/main/java/org/locationtech/geowave/datastore/rocksdb/util/RocksDBClient.java
+++ b/extensions/datastores/rocksdb/src/main/java/org/locationtech/geowave/datastore/rocksdb/util/RocksDBClient.java
@@ -295,10 +295,7 @@ public class RocksDBClient implements Closeable {
     final String prefix = RocksDBUtils.getTablePrefix(typeName, indexName);
     for (final Entry<String, CacheKey> e : keyCache.asMap().entrySet()) {
       final String key = e.getKey();
-      // BUGFIX: This string compare was failing due to a separator in the file path
-      // It seems like 'contains' is a better choice, but alternately could fix like this:
-      // if (key.substring(subDirectory.length()+1).startsWith(prefix)) {
-      if (key.contains(prefix)) {
+      if (key.substring(subDirectory.length() + 1).startsWith(prefix)) {
         keyCache.invalidate(key);
         AbstractRocksDBTable indexTable = indexTableCache.getIfPresent(e.getValue());
         if (indexTable == null) {
@@ -306,6 +303,7 @@ public class RocksDBClient implements Closeable {
         }
         if (indexTable != null) {
           indexTableCache.invalidate(e.getValue());
+          dataIndexTableCache.invalidate(e.getValue());
           indexTable.close();
         }
       }


### PR DESCRIPTION
Two small fixes in the close method: there was an error in the compare logic for the cache key vs the index to close; also, one of the caches was not being cleared.