### PR TITLE
Add some docs for core classes

### DIFF
--- a/core/store/src/main/java/org/locationtech/geowave/core/store/operations/MetadataDeleter.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/operations/MetadataDeleter.java
@@ -8,8 +8,29 @@
  */
 package org.locationtech.geowave.core.store.operations;
 
+/**
+ * TProvides an interface for deleting GeoWave metadata. A {@link MetadataQuery} is used to specify the metadata to be deleted.
+ *
+ * Delete queries may only be performed if the deleter is not closed.
+ */
 public interface MetadataDeleter extends AutoCloseable {
-  public boolean delete(MetadataQuery query);
+  /**
+   * Delete metadata from the DB.
+   *
+   * Preconditions:
+   * <ul> <li>The deleter is not closed</li> </ul>
+   *
+   * @param query The query that specifies the metadata to be deleted.
+   * @return {@code true} if an object matching the query was found and successfully deleted, {@code false} otherwise.
+   */
+  boolean delete(MetadataQuery query);
 
-  public void flush();
+  /**
+   * Flush the deleter, committing all pending changes. Note that the changes may already be
+   * committed - this method just establishes that they *must* be committed after the method
+   * returns.
+   *
+   * Preconditions: <ul> <li>The deleter is not closed</li> </ul>
+   */
+  void flush();
 }

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/operations/MetadataDeleter.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/operations/MetadataDeleter.java
@@ -9,7 +9,7 @@
 package org.locationtech.geowave.core.store.operations;
 
 /**
- * TProvides an interface for deleting GeoWave metadata. A {@link MetadataQuery} is used to specify the metadata to be deleted.
+ * Provides an interface for deleting GeoWave metadata. A {@link MetadataQuery} is used to specify the metadata to be deleted.
  *
  * Delete queries may only be performed if the deleter is not closed.
  */

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/operations/MetadataReader.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/operations/MetadataReader.java
@@ -11,6 +11,15 @@ package org.locationtech.geowave.core.store.operations;
 import org.locationtech.geowave.core.store.CloseableIterator;
 import org.locationtech.geowave.core.store.entities.GeoWaveMetadata;
 
+/**
+ * Provides an interface for reading GeoWave metadata. A {@link MetadataQuery} is used to specify the metadata to be read.
+ */
 public interface MetadataReader {
-  public CloseableIterator<GeoWaveMetadata> query(MetadataQuery query);
+  /**
+   * Read metadata, as specified by the query.
+   *
+   * @param query The query that specifies the metadata to be read.
+   * @return An iterator that lazily loads the metadata as they are requested.
+   */
+  CloseableIterator<GeoWaveMetadata> query(MetadataQuery query);
 }

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/operations/MetadataWriter.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/operations/MetadataWriter.java
@@ -10,8 +10,28 @@ package org.locationtech.geowave.core.store.operations;
 
 import org.locationtech.geowave.core.store.entities.GeoWaveMetadata;
 
+/**
+ * Provides an interface for persisting metadata.
+ *
+ * Writes may only be performed as long as the instance is not closed.
+ */
 public interface MetadataWriter extends AutoCloseable {
-  public void write(GeoWaveMetadata metadata);
+  /**
+   * Write metadata to the table.
+   *
+   * Preconditions:
+   * <ul> <li>The writer is not closed</li> </ul>
+   *
+   * @param metadata The metadata.
+   */
+  void write(GeoWaveMetadata metadata);
 
-  public void flush();
+  /**
+   * Flush the writer, committing all pending writes. Note that the writes may already be committed
+   * - this method just establishes that they *must* be committed after the method returns.
+   *
+   * Preconditions:
+   * <ul> <li>The writer is not closed</li> </ul>
+   */
+  void flush();
 }

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/operations/RowDeleter.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/operations/RowDeleter.java
@@ -11,11 +11,25 @@ package org.locationtech.geowave.core.store.operations;
 import java.io.Closeable;
 import org.locationtech.geowave.core.store.entities.GeoWaveRow;
 
+/**
+ * Provides an interface for deleting GeoWave data rows.
+ */
 public interface RowDeleter extends Closeable {
+  /**
+   * Delete a GeoWave row from the DB.
+   *
+   * Preconditions: <ul> <li>The deleter is not closed</li> </ul>
+   *
+   * @param row The row to delete.
+   */
   void delete(GeoWaveRow row);
 
+  /**
+   * Flush the deleter, committing all pending changes. Note that the changes may already be
+   * committed - this method just establishes that they *must* be committed after the method
+   * returns.
+   *
+   * Preconditions: <ul> <li>The deleter is not closed</li> </ul>
+   */
   void flush();
-
-  @Override
-  void close();
 }

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/operations/RowDeleter.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/operations/RowDeleter.java
@@ -32,4 +32,11 @@ public interface RowDeleter extends Closeable {
    * Preconditions: <ul> <li>The deleter is not closed</li> </ul>
    */
   void flush();
+  
+  /**
+   * Close the deleter, committing all pending changes.
+   * This method is overridden because it does not throw an IOException.
+   */
+  @Override
+  void close();
 }

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/operations/RowWriter.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/operations/RowWriter.java
@@ -16,9 +16,29 @@ import org.locationtech.geowave.core.store.entities.GeoWaveRow;
  * BatchWriter but can be overridden for other mechanisms to write the data.
  */
 public interface RowWriter extends AutoCloseable {
-  public void write(GeoWaveRow[] rows);
+  /**
+   * Write multiple GeoWave rows to the DB.
+   *
+   * Preconditions: <ul> <li>The writer is not closed</li> </ul>
+   *
+   * @param rows The array of rows to be written.
+   */
+  void write(GeoWaveRow[] rows);
 
-  public void write(GeoWaveRow row);
+  /**
+   * Write a GeoWave row to the DB.
+   *
+   * Preconditions: <ul> <li>The writer is not closed</li> </ul>
+   *
+   * @param row The row to be written.
+   */
+  void write(GeoWaveRow row);
 
-  public void flush();
+  /**
+   * Flush the writer, committing all pending writes. Note that the writes may already be committed
+   * - this method just establishes that they *must* be committed after the method returns.
+   *
+   * Preconditions: <ul> <li>The writer is not closed</li> </ul>
+   */
+  void flush();
 }


### PR DESCRIPTION
Add javadocs for {Metadata, Row} x {Reader, Writer, Deleter}. We also removed `public` from interface methods since it's redundant (interface methods can't have any other access level in Java 8).