### PR TITLE
fixed issue with deleting from custom index

### DIFF
--- a/core/store/src/main/java/org/locationtech/geowave/core/store/adapter/LazyReadPersistenceEncoding.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/adapter/LazyReadPersistenceEncoding.java
@@ -166,7 +166,7 @@ public class LazyReadPersistenceEncoding extends IndexedAdapterPersistenceEncodi
               value.getFieldMask(),
               value.getValue(),
               value.getVisibility(),
-              -1).getFieldsRead();
+              -2).getFieldsRead();
       for (final FlattenedFieldInfo fieldInfo : fieldInfos) {
         final String fieldName =
             dataAdapter.getFieldNameForPosition(

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/callback/DuplicateDeletionCallback.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/callback/DuplicateDeletionCallback.java
@@ -88,14 +88,20 @@ public class DuplicateDeletionCallback<T> implements DeleteCallback<T, GeoWaveRo
           final InsertionIds ids = DataStoreUtils.getInsertionIdsForEntry(entry, adapter, index);
           for (final SinglePartitionInsertionIds insertId : ids.getPartitionKeys()) {
             for (final byte[] sortKey : insertId.getSortKeys()) {
-              insertionIds.add(new InsertionIdData(insertId.getPartitionKey(), sortKey));
+              insertionIds.add(
+                  new InsertionIdData(
+                      insertId.getPartitionKey() == null ? new byte[0] : insertId.getPartitionKey(),
+                      sortKey == null ? new byte[0] : sortKey));
             }
           }
         }
         final Set<InsertionIdData> i = insertionIds;
         // we need to do is remove the rows in this callback. marking them as deleted
         Arrays.stream(rows).forEach(
-            row -> i.remove(new InsertionIdData(row.getPartitionKey(), row.getSortKey())));
+            row -> i.remove(
+                new InsertionIdData(
+                    row.getPartitionKey() == null ? new byte[0] : row.getPartitionKey(),
+                    row.getSortKey() == null ? new byte[0] : row.getSortKey())));
       }
     }
   }

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/callback/DuplicateDeletionCallback.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/callback/DuplicateDeletionCallback.java
@@ -88,20 +88,24 @@ public class DuplicateDeletionCallback<T> implements DeleteCallback<T, GeoWaveRo
           final InsertionIds ids = DataStoreUtils.getInsertionIdsForEntry(entry, adapter, index);
           for (final SinglePartitionInsertionIds insertId : ids.getPartitionKeys()) {
             for (final byte[] sortKey : insertId.getSortKeys()) {
+              byte[] partitionKey = insertId.getPartitionKey();
               insertionIds.add(
                   new InsertionIdData(
-                      insertId.getPartitionKey() == null ? new byte[0] : insertId.getPartitionKey(),
+                      partitionKey == null ? new byte[0] : partitionKey,
                       sortKey == null ? new byte[0] : sortKey));
             }
           }
         }
         final Set<InsertionIdData> i = insertionIds;
         // we need to do is remove the rows in this callback. marking them as deleted
-        Arrays.stream(rows).forEach(
-            row -> i.remove(
-                new InsertionIdData(
-                    row.getPartitionKey() == null ? new byte[0] : row.getPartitionKey(),
-                    row.getSortKey() == null ? new byte[0] : row.getSortKey())));
+        Arrays.stream(rows).forEach(row -> {
+          byte[] partitionKey = row.getPartitionKey();
+          byte[] sortKey = row.getSortKey();
+          i.remove(
+              new InsertionIdData(
+                  partitionKey == null ? new byte[0] : partitionKey,
+                  sortKey == null ? new byte[0] : sortKey));
+        });
       }
     }
   }

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/query/constraints/InsertionIdQuery.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/query/constraints/InsertionIdQuery.java
@@ -27,9 +27,9 @@ public class InsertionIdQuery implements QueryConstraints {
   public InsertionIdQuery() {}
 
   public InsertionIdQuery(final byte[] partitionKey, final byte[] sortKey, final byte[] dataId) {
-    this.partitionKey = partitionKey;
-    this.sortKey = sortKey;
-    this.dataId = dataId;
+    this.partitionKey = partitionKey == null ? new byte[0] : partitionKey;
+    this.sortKey = sortKey == null ? new byte[0] : sortKey;
+    this.dataId = dataId == null ? new byte[0] : dataId;
   }
 
   public byte[] getPartitionKey() {

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/util/DataStoreUtils.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/util/DataStoreUtils.java
@@ -299,7 +299,7 @@ public class DataStoreUtils {
           final ByteBuffer input = ByteBuffer.wrap(flattenedValue);
           for (int i = 0; i < fieldPositions.size(); i++) {
             final Integer fieldPosition = fieldPositions.get(i);
-            if ((maxFieldPosition > -1) && (fieldPosition > maxFieldPosition)) {
+            if ((maxFieldPosition > -2) && (fieldPosition > maxFieldPosition)) {
               return new FlattenedDataSet(
                   fieldInfoList,
                   new FlattenedUnreadDataSingleRow(input, i, fieldPositions));

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/util/DataStoreUtils.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/util/DataStoreUtils.java
@@ -73,6 +73,7 @@ import org.locationtech.geowave.core.store.flatten.FlattenedUnreadDataSingleRow;
 import org.locationtech.geowave.core.store.index.CommonIndexModel;
 import org.locationtech.geowave.core.store.index.CommonIndexValue;
 import org.locationtech.geowave.core.store.index.CustomIndexImpl;
+import org.locationtech.geowave.core.store.index.CustomIndexStrategy;
 import org.locationtech.geowave.core.store.index.IndexStore;
 import org.locationtech.geowave.core.store.operations.DataStoreOperations;
 import org.locationtech.geowave.core.store.operations.MetadataType;
@@ -217,8 +218,12 @@ public class DataStoreUtils {
       final T entry,
       final InternalDataAdapter adapter,
       final Index index) {
-    final AdapterPersistenceEncoding encoding = adapter.encode(entry, index.getIndexModel());
-    return encoding.getInsertionIds(index);
+    if (index instanceof CustomIndexStrategy) {
+      return ((CustomIndexStrategy) index).getInsertionIds(entry);
+    } else {
+      final AdapterPersistenceEncoding encoding = adapter.encode(entry, index.getIndexModel());
+      return encoding.getInsertionIds(index);
+    }
   }
 
   public static InsertionIds keysToInsertionIds(final GeoWaveKey... geoWaveKeys) {

--- a/extensions/datastores/cassandra/src/main/java/org/locationtech/geowave/datastore/cassandra/CassandraRow.java
+++ b/extensions/datastores/cassandra/src/main/java/org/locationtech/geowave/datastore/cassandra/CassandraRow.java
@@ -11,9 +11,11 @@ package org.locationtech.geowave.datastore.cassandra;
 import java.util.function.BiConsumer;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.log4j.Logger;
+import org.bouncycastle.util.Arrays;
 import org.locationtech.geowave.core.store.entities.GeoWaveValue;
 import org.locationtech.geowave.core.store.entities.GeoWaveValueImpl;
 import org.locationtech.geowave.core.store.entities.MergeableGeoWaveRow;
+import org.locationtech.geowave.datastore.cassandra.util.CassandraUtils;
 import com.datastax.driver.core.DataType;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.schemabuilder.Create;
@@ -121,7 +123,12 @@ public class CassandraRow extends MergeableGeoWaveRow {
 
   @Override
   public byte[] getPartitionKey() {
-    return row.getBytes(CassandraField.GW_PARTITION_ID_KEY.getFieldName()).array();
+    byte[] partitionKey = row.getBytes(CassandraField.GW_PARTITION_ID_KEY.getFieldName()).array();
+    if (Arrays.areEqual(CassandraUtils.EMPTY_PARTITION_KEY, partitionKey)) {
+      // we shouldn't expose the reserved "empty" partition key externally
+      return new byte[0];
+    }
+    return partitionKey;
   }
 
   @Override

--- a/extensions/datastores/cassandra/src/main/java/org/locationtech/geowave/datastore/cassandra/operations/BatchedRangeRead.java
+++ b/extensions/datastores/cassandra/src/main/java/org/locationtech/geowave/datastore/cassandra/operations/BatchedRangeRead.java
@@ -83,10 +83,7 @@ public class BatchedRangeRead<T> {
   public CloseableIterator<T> results() {
     final List<BoundStatement> statements = new ArrayList<>();
     for (final SinglePartitionQueryRanges r : ranges) {
-      final byte[] partitionKey =
-          ((r.getPartitionKey() == null) || (r.getPartitionKey().length == 0))
-              ? CassandraUtils.EMPTY_PARTITION_KEY
-              : r.getPartitionKey();
+      final byte[] partitionKey = CassandraUtils.getCassandraSafePartitionKey(r.getPartitionKey());
       for (final ByteArrayRange range : r.getSortKeyRanges()) {
         final BoundStatement boundRead = new BoundStatement(preparedRead);
         final byte[] start = range.getStart() != null ? range.getStart() : new byte[0];

--- a/extensions/datastores/cassandra/src/main/java/org/locationtech/geowave/datastore/cassandra/operations/CassandraOperations.java
+++ b/extensions/datastores/cassandra/src/main/java/org/locationtech/geowave/datastore/cassandra/operations/CassandraOperations.java
@@ -55,6 +55,7 @@ import org.locationtech.geowave.datastore.cassandra.CassandraRow;
 import org.locationtech.geowave.datastore.cassandra.CassandraRow.CassandraField;
 import org.locationtech.geowave.datastore.cassandra.config.CassandraOptions;
 import org.locationtech.geowave.datastore.cassandra.config.CassandraRequiredOptions;
+import org.locationtech.geowave.datastore.cassandra.util.CassandraUtils;
 import org.locationtech.geowave.datastore.cassandra.util.KeyspaceStatePool;
 import org.locationtech.geowave.datastore.cassandra.util.KeyspaceStatePool.KeyspaceState;
 import org.locationtech.geowave.datastore.cassandra.util.SessionPool;
@@ -302,20 +303,21 @@ public class CassandraOperations implements MapReduceDataStoreOperations {
               QueryBuilder.delete().from(gwNamespace, getCassandraSafeName(tableName)).where(
                   QueryBuilder.eq(
                       CassandraField.GW_PARTITION_ID_KEY.getFieldName(),
-                      ByteBuffer.wrap(row.getPartitionKey()))).and(
-                          QueryBuilder.eq(
-                              CassandraField.GW_SORT_KEY.getFieldName(),
-                              ByteBuffer.wrap(row.getSortKey()))).and(
-                                  QueryBuilder.eq(
-                                      CassandraField.GW_ADAPTER_ID_KEY.getFieldName(),
-                                      row.getAdapterId())).and(
-                                          QueryBuilder.eq(
-                                              CassandraField.GW_DATA_ID_KEY.getFieldName(),
-                                              ByteBuffer.wrap(row.getDataId()))).and(
-                                                  QueryBuilder.eq(
-                                                      CassandraField.GW_FIELD_VISIBILITY_KEY.getFieldName(),
-                                                      ByteBuffer.wrap(
-                                                          row.getFieldValues()[i].getVisibility()))));
+                      ByteBuffer.wrap(
+                          CassandraUtils.getCassandraSafePartitionKey(row.getPartitionKey())))).and(
+                              QueryBuilder.eq(
+                                  CassandraField.GW_SORT_KEY.getFieldName(),
+                                  ByteBuffer.wrap(row.getSortKey()))).and(
+                                      QueryBuilder.eq(
+                                          CassandraField.GW_ADAPTER_ID_KEY.getFieldName(),
+                                          row.getAdapterId())).and(
+                                              QueryBuilder.eq(
+                                                  CassandraField.GW_DATA_ID_KEY.getFieldName(),
+                                                  ByteBuffer.wrap(row.getDataId()))).and(
+                                                      QueryBuilder.eq(
+                                                          CassandraField.GW_FIELD_VISIBILITY_KEY.getFieldName(),
+                                                          ByteBuffer.wrap(
+                                                              row.getFieldValues()[i].getVisibility()))));
       exhausted &= rs.isExhausted();
     }
 

--- a/extensions/datastores/cassandra/src/main/java/org/locationtech/geowave/datastore/cassandra/util/CassandraUtils.java
+++ b/extensions/datastores/cassandra/src/main/java/org/locationtech/geowave/datastore/cassandra/util/CassandraUtils.java
@@ -20,7 +20,16 @@ public class CassandraUtils {
 
   // because Cassandra requires a partition key, if the geowave partition key is
   // empty, we need a non-empty constant alternative
-  public static final byte[] EMPTY_PARTITION_KEY = new byte[] {0};
+  public static final byte[] EMPTY_PARTITION_KEY = new byte[] {-1};
+
+  public static byte[] getCassandraSafePartitionKey(final byte[] partitionKey) {
+    // Cassandra requires a non-empty partition key so we need to use a reserved byte array to
+    // indicate an empty partition key
+    if ((partitionKey == null) || (partitionKey.length == 0)) {
+      return EMPTY_PARTITION_KEY;
+    }
+    return partitionKey;
+  }
 
   public static BoundStatement[] bindInsertion(
       final PreparedStatement insertionStatement,
@@ -36,10 +45,7 @@ public class CassandraUtils {
       final GeoWaveRow row,
       final boolean visibilityEnabled) {
     // the data ID becomes the partition key and the only other fields are the value and adapter ID
-    byte[] partitionKey = row.getDataId();
-    if ((partitionKey == null) || (partitionKey.length == 0)) {
-      partitionKey = EMPTY_PARTITION_KEY;
-    }
+    byte[] partitionKey = getCassandraSafePartitionKey(row.getDataId());
     final BoundStatement[] retVal = new BoundStatement[row.getFieldValues().length];
     int i = 0;
     for (final GeoWaveValue value : row.getFieldValues()) {
@@ -66,10 +72,7 @@ public class CassandraUtils {
   public static BoundStatement[] bindInsertion(
       final PreparedStatement insertionStatement,
       final GeoWaveRow row) {
-    byte[] partitionKey = row.getPartitionKey();
-    if ((partitionKey == null) || (partitionKey.length == 0)) {
-      partitionKey = EMPTY_PARTITION_KEY;
-    }
+    byte[] partitionKey = getCassandraSafePartitionKey(row.getPartitionKey());
     final BoundStatement[] retVal = new BoundStatement[row.getFieldValues().length];
     int i = 0;
     for (final GeoWaveValue value : row.getFieldValues()) {

--- a/extensions/datastores/dynamodb/src/main/java/org/locationtech/geowave/datastore/dynamodb/DynamoDBRow.java
+++ b/extensions/datastores/dynamodb/src/main/java/org/locationtech/geowave/datastore/dynamodb/DynamoDBRow.java
@@ -12,6 +12,7 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import org.bouncycastle.util.Arrays;
 import org.locationtech.geowave.core.index.ByteArrayUtils;
 import org.locationtech.geowave.core.store.entities.GeoWaveKey;
 import org.locationtech.geowave.core.store.entities.GeoWaveKeyImpl;
@@ -80,7 +81,8 @@ public class DynamoDBRow extends MergeableGeoWaveRow implements GeoWaveRow {
     return new GeoWaveKeyImpl(
         dataId,
         internalAdapterId,
-        partitionKey,
+        Arrays.areEqual(DynamoDBUtils.EMPTY_PARTITION_KEY, partitionKey) ? new byte[0]
+            : partitionKey,
         DynamoDBUtils.decodeSortableBase64(sortKey),
         numberOfDuplicates);
   }

--- a/extensions/datastores/dynamodb/src/main/java/org/locationtech/geowave/datastore/dynamodb/operations/DynamoDBReader.java
+++ b/extensions/datastores/dynamodb/src/main/java/org/locationtech/geowave/datastore/dynamodb/operations/DynamoDBReader.java
@@ -347,10 +347,7 @@ public class DynamoDBReader<T> implements RowReader<T> {
       short[] adapterIds,
       final InternalAdapterStore adapterStore) {
     final List<QueryRequest> retVal = new ArrayList<>();
-    final byte[] partitionKey =
-        ((r.getPartitionKey() == null) || (r.getPartitionKey().length == 0))
-            ? DynamoDBWriter.EMPTY_PARTITION_KEY
-            : r.getPartitionKey();
+    final byte[] partitionKey = DynamoDBUtils.getDynamoDBSafePartitionKey(r.getPartitionKey());
     if (((adapterIds == null) || (adapterIds.length == 0)) && (adapterStore != null)) {
       adapterIds = adapterStore.getAdapterIds();
     }

--- a/extensions/datastores/dynamodb/src/main/java/org/locationtech/geowave/datastore/dynamodb/util/DynamoDBUtils.java
+++ b/extensions/datastores/dynamodb/src/main/java/org/locationtech/geowave/datastore/dynamodb/util/DynamoDBUtils.java
@@ -16,11 +16,24 @@ import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.util.Base64;
 
 public class DynamoDBUtils {
+  // because DynamoDB requires a hash key, if the geowave partition key is
+  // empty, we need a non-empty constant alternative
+  public static final byte[] EMPTY_PARTITION_KEY = new byte[] {-1};
+
   public static class NoopClosableIteratorWrapper implements Closeable {
     public NoopClosableIteratorWrapper() {}
 
     @Override
     public void close() {}
+  }
+
+  public static byte[] getDynamoDBSafePartitionKey(final byte[] partitionKey) {
+    // DynamoDB requires a non-empty partition key so we need to use a reserved byte array to
+    // indicate an empty partition key
+    if ((partitionKey == null) || (partitionKey.length == 0)) {
+      return EMPTY_PARTITION_KEY;
+    }
+    return partitionKey;
   }
 
   public static byte[] getPrimaryId(final Map<String, AttributeValue> map) {

--- a/test/src/test/java/org/locationtech/geowave/test/basic/GeoWaveCustomIndexIT.java
+++ b/test/src/test/java/org/locationtech/geowave/test/basic/GeoWaveCustomIndexIT.java
@@ -166,28 +166,28 @@ public class GeoWaveCustomIndexIT {
     if (spatialTemporal) {
       // if spatial/temporal indexing exists explicitly set the appropriate one
       bldr.indexName(new SpatialIndexBuilder().createIndex().getName());
-    }
-    try (CloseableIterator<SimpleFeature> it =
-        dataStore.query(
-            bldr.constraints(
-                bldr.constraintsFactory().spatialTemporalConstraints().spatialConstraints(
-                    GeometryUtils.GEOMETRY_FACTORY.toGeometry(
-                        new Envelope(0, 2, 0, 2))).build()).build())) {
-      Assert.assertEquals(27, Iterators.size(it));
-    }
-    if (spatialTemporal) {
+
+      try (CloseableIterator<SimpleFeature> it =
+          dataStore.query(
+              bldr.constraints(
+                  bldr.constraintsFactory().spatialTemporalConstraints().spatialConstraints(
+                      GeometryUtils.GEOMETRY_FACTORY.toGeometry(
+                          new Envelope(0, 2, 0, 2))).build()).build())) {
+        Assert.assertEquals(27, Iterators.size(it));
+      }
       // if spatial/temporal indexing exists explicitly set the appropriate one
       bldr.indexName(new SpatialTemporalIndexBuilder().createIndex().getName());
-    }
-    try (CloseableIterator<SimpleFeature> it =
-        dataStore.query(
-            bldr.constraints(
-                bldr.constraintsFactory().spatialTemporalConstraints().spatialConstraints(
-                    GeometryUtils.GEOMETRY_FACTORY.toGeometry(
-                        new Envelope(0, 2, 0, 2))).addTimeRange(
-                            startQueryTime,
-                            endQueryTime).build()).build())) {
-      Assert.assertEquals(9, Iterators.size(it));
+
+      try (CloseableIterator<SimpleFeature> it =
+          dataStore.query(
+              bldr.constraints(
+                  bldr.constraintsFactory().spatialTemporalConstraints().spatialConstraints(
+                      GeometryUtils.GEOMETRY_FACTORY.toGeometry(
+                          new Envelope(0, 2, 0, 2))).addTimeRange(
+                              startQueryTime,
+                              endQueryTime).build()).build())) {
+        Assert.assertEquals(9, Iterators.size(it));
+      }
     }
     try (CloseableIterator<SimpleFeature> it =
         dataStore.query(

--- a/test/src/test/java/org/locationtech/geowave/test/basic/GeoWaveCustomIndexIT.java
+++ b/test/src/test/java/org/locationtech/geowave/test/basic/GeoWaveCustomIndexIT.java
@@ -166,28 +166,28 @@ public class GeoWaveCustomIndexIT {
     if (spatialTemporal) {
       // if spatial/temporal indexing exists explicitly set the appropriate one
       bldr.indexName(new SpatialIndexBuilder().createIndex().getName());
-
-      try (CloseableIterator<SimpleFeature> it =
-          dataStore.query(
-              bldr.constraints(
-                  bldr.constraintsFactory().spatialTemporalConstraints().spatialConstraints(
-                      GeometryUtils.GEOMETRY_FACTORY.toGeometry(
-                          new Envelope(0, 2, 0, 2))).build()).build())) {
-        Assert.assertEquals(27, Iterators.size(it));
-      }
+    }
+    try (CloseableIterator<SimpleFeature> it =
+        dataStore.query(
+            bldr.constraints(
+                bldr.constraintsFactory().spatialTemporalConstraints().spatialConstraints(
+                    GeometryUtils.GEOMETRY_FACTORY.toGeometry(
+                        new Envelope(0, 2, 0, 2))).build()).build())) {
+      Assert.assertEquals(27, Iterators.size(it));
+    }
+    if (spatialTemporal) {
       // if spatial/temporal indexing exists explicitly set the appropriate one
       bldr.indexName(new SpatialTemporalIndexBuilder().createIndex().getName());
-
-      try (CloseableIterator<SimpleFeature> it =
-          dataStore.query(
-              bldr.constraints(
-                  bldr.constraintsFactory().spatialTemporalConstraints().spatialConstraints(
-                      GeometryUtils.GEOMETRY_FACTORY.toGeometry(
-                          new Envelope(0, 2, 0, 2))).addTimeRange(
-                              startQueryTime,
-                              endQueryTime).build()).build())) {
-        Assert.assertEquals(9, Iterators.size(it));
-      }
+    }
+    try (CloseableIterator<SimpleFeature> it =
+        dataStore.query(
+            bldr.constraints(
+                bldr.constraintsFactory().spatialTemporalConstraints().spatialConstraints(
+                    GeometryUtils.GEOMETRY_FACTORY.toGeometry(
+                        new Envelope(0, 2, 0, 2))).addTimeRange(
+                            startQueryTime,
+                            endQueryTime).build()).build())) {
+      Assert.assertEquals(9, Iterators.size(it));
     }
     try (CloseableIterator<SimpleFeature> it =
         dataStore.query(


### PR DESCRIPTION
There was a relatively minor issue simply when deleting from a custom index that was originally masked by issue #1655 and the multi-index deletion issues.  Added a test for the custom index query and deletion all by itself along with another test for deletion with the custom index, spatial, and spatial-temporal indices.  The commented line with the TODO still exists with the multi-index deletion bug, but this resolves simply deletion from the custom index.