### PR TITLE
Fix JAI Error on CLI

### DIFF
--- a/extensions/formats/geotools-raster/pom.xml
+++ b/extensions/formats/geotools-raster/pom.xml
@@ -27,10 +27,23 @@
 			<groupId>org.geotools</groupId>
 			<artifactId>gt-netcdf</artifactId>
 			<version>${geotools.version}</version>
+			<scope>${geotools.scope}</scope>
 			<exclusions>
 				<exclusion>
 					<groupId>org.slf4j</groupId>
 					<artifactId>log4j-over-slf4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>it.geosolutions.imageio-ext</groupId>
+					<artifactId>imageio-ext-imagereadmt</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>it.geosolutions.imageio-ext</groupId>
+					<artifactId>imageio-ext-utilities</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>it.geosolutions.imageio-ext</groupId>
+					<artifactId>imageio-ext-geocore</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>


### PR DESCRIPTION
This PR fixes the following error:
`Error while parsing JAI registry file "file:/Applications/GeoWave/lib/ingest-formats/gt-raster/imageio-ext-imagereadmt-1.1.25.jar!/META-INF/registryFile.jai" :
Error in registry file at line number #29
A descriptor is already registered against the name "ImageReadMT" under registry mode "rendered"`

It seems to have been caused by there being multiple instances of imageio-ext-imagereadmt.jar on the classpath.