### PR TITLE
Fix issues with missing NetCDF dependencies

### DIFF
--- a/deploy/pom.xml
+++ b/deploy/pom.xml
@@ -298,7 +298,7 @@
 							<dependency>
 								<groupId>org.locationtech.geowave</groupId>
 								<artifactId>geowave-dev-resources</artifactId>
-								<version>1.6</version>
+								<version>${geowave-dev-resources.version}</version>
 							</dependency>
 						</dependencies>
 					</plugin>

--- a/dev-resources/pom.xml
+++ b/dev-resources/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>geowave-dev-resources</artifactId>
 	<groupId>org.locationtech.geowave</groupId>
-	<version>1.6</version>
+	<version>1.7</version>
 	<name>GeoWave Development Resources</name>
 	<packaging>jar</packaging>
 	<description>Development resources and settings for geowave</description>

--- a/dev-resources/src/main/resources/assemblies/default-installer-plugin.xml
+++ b/dev-resources/src/main/resources/assemblies/default-installer-plugin.xml
@@ -23,6 +23,7 @@
 				<exclude>io.netty:*</exclude>
 				<exclude>com.fasterxml.jackson.core:*</exclude>
 				<exclude>*:jsr305</exclude>
+				<exclude>org.apache.httpcomponents:httpcore</exclude>
 				<exclude>org.apache.hadoop:hadoop-client</exclude>
 				<exclude>org.apache.hadoop:hadoop-auth</exclude>
 				<exclude>org.apache.hadoop:hadoop-annotations</exclude>
@@ -39,6 +40,7 @@
 				<exclude>org.apache.spark:spark-sql*</exclude>
 				<exclude>org.apache.spark:spark-tags*</exclude>
 				<exclude>com.google.guava:guava</exclude>
+				<exclude>org.locationtech.jts:jts-core</exclude>
 				<exclude>*:commons-io</exclude>
 				<exclude>*:commons-vfs2</exclude>
 				<exclude>*:commons-lang</exclude>
@@ -59,6 +61,8 @@
 				<exclude>*:log4j</exclude>
 				<exclude>*:zookeeper</exclude>
 				<exclude>*:metrics-core</exclude>
+				<exclude>joda-time:joda-time</exclude>
+				<exclude>net.jcip:jcip-annotations</exclude>
 				<exclude>com.google.code.gson:gson</exclude>
 				<exclude>com.google.protobuf:protobuf-java</exclude>
 				<exclude>com.amazonaws:aws-java-sdk-s3</exclude>
@@ -66,12 +70,25 @@
 				<exclude>com.amazonaws:aws-java-sdk-core</exclude>
 				<exclude>com.aol.simplereact:cyclops-react</exclude>
 				<exclude>com.github.spotbugs:spotbugs-annotations</exclude>
-				<exclude>org.geotools:gt-main</exclude>
-				<exclude>org.geotools:gt-coverage</exclude>
+				<exclude>org.geotools:gt-main:jar:</exclude>
+				<exclude>org.geotools:gt-coverage:jar:</exclude>
+				<exclude>org.geotools:gt-image:jar:</exclude>
+				<exclude>org.geotools:gt-imagemosaic:jar:</exclude>
+				<exclude>org.geotools:gt-jdbc:jar:</exclude>
+				<exclude>org.geotools:gt-shapefile:jar:</exclude>
+				<exclude>org.geotools:gt-transform:jar:</exclude>
+				<exclude>org.geotools.ogc:net.opengis.ows:jar:</exclude>
+				<exclude>org.geotools.ogc:org.w3.xlink:jar:</exclude>
+				<exclude>org.eclipse.emf:org.eclipse.emf.common:jar:</exclude>
+				<exclude>org.eclipse.emf:org.eclipse.emf.ecore:jar:</exclude>
+				<exclude>org.eclipse.emf:org.eclipse.emf.ecore.xmi:jar:</exclude>
 				<exclude>javax.media:jai_core</exclude>
 				<exclude>javax.media:jai_codec</exclude>
 				<exclude>javax.media:jai_imageio</exclude>
 				<exclude>it.geosolutions.imageio-ext:imageio-ext-gdalframework</exclude>
+				<exclude>it.geosolutions.imageio-ext:imageio-ext-geocore</exclude>
+				<exclude>it.geosolutions.imageio-ext:imageio-ext-imagereadmt</exclude>
+				<exclude>it.geosolutions.imageio-ext:imageio-ext-utilities</exclude>
 			</excludes>
 			<scope>runtime</scope>
 			<useTransitiveDependencies>true</useTransitiveDependencies>

--- a/extensions/formats/geotools-raster/pom.xml
+++ b/extensions/formats/geotools-raster/pom.xml
@@ -27,7 +27,6 @@
 			<groupId>org.geotools</groupId>
 			<artifactId>gt-netcdf</artifactId>
 			<version>${geotools.version}</version>
-			<scope>${geotools.scope}</scope>
 			<exclusions>
 				<exclusion>
 					<groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
 		</developer>
 	</developers>
 	<properties>
+		<geowave-dev-resources.version>1.7</geowave-dev-resources.version>
 		<spark.version>2.3.1</spark.version>
 		<geotools.version>20.0</geotools.version>
 		<jts.version>1.16.0</jts.version>
@@ -973,7 +974,7 @@
 						<dependency>
 							<groupId>org.locationtech.geowave</groupId>
 							<artifactId>geowave-dev-resources</artifactId>
-							<version>1.6</version>
+							<version>${geowave-dev-resources.version}</version>
 						</dependency>
 					</dependencies>
 				</plugin>
@@ -1271,7 +1272,7 @@
 					<dependency>
 						<groupId>org.locationtech.geowave</groupId>
 						<artifactId>geowave-dev-resources</artifactId>
-						<version>1.5</version>
+						<version>${geowave-dev-resources.version}</version>
 					</dependency>
 				</dependencies>
 			</plugin>
@@ -1362,7 +1363,7 @@
 								<dependency>
 									<groupId>org.locationtech.geowave</groupId>
 									<artifactId>geowave-dev-resources</artifactId>
-									<version>1.5</version>
+									<version>${geowave-dev-resources.version}</version>
 								</dependency>
 							</dependencies>
 						</plugin>


### PR DESCRIPTION
There was an exclusion in the installer plugin assembly profile for `gt-coverage`, which was causing `gt-coverage-api` to get excluded, which was a dependency needed by gt-netcdf.  I updated the exclusion to be more specific, and also added some more exclusions to reduce the number of duplicated dependencies in the installed geotools raster plugin.