### PR TITLE
GEOWAVE-1674: flexibility to have newer versions of jcommander in classpath

### DIFF
--- a/core/cli/src/main/java/org/locationtech/geowave/core/cli/prefix/JCommanderPrefixTranslator.java
+++ b/core/cli/src/main/java/org/locationtech/geowave/core/cli/prefix/JCommanderPrefixTranslator.java
@@ -35,8 +35,8 @@ public class JCommanderPrefixTranslator {
   // which is a special JCommander class. If the interface changes in the
   // future, this
   // may not work anymore.
-  private final Field paraField;
-  private final Field paraMethod;
+  private Field paraField;
+  private Field paraMethod;
 
   public JCommanderPrefixTranslator() {
     try {
@@ -50,9 +50,18 @@ public class JCommanderPrefixTranslator {
       paraMethod.setAccessible(true);
     } catch (final NoSuchFieldException e) {
       // This is a programmer error, and will only happen if another
-      // version
-      // of JCommander is being used.
-      throw new RuntimeException(e);
+      // version of JCommander is being used.
+      // newer versions of JCommander have renamed the member variables, try the new names
+      try {
+        paraField = Parameterized.class.getDeclaredField("field");
+
+        paraField.setAccessible(true);
+
+        paraMethod = Parameterized.class.getDeclaredField("method");
+        paraMethod.setAccessible(true);
+      } catch (NoSuchFieldException e2) {
+        throw new RuntimeException(e);
+      }
     }
   }
 


### PR DESCRIPTION
JCommander changed the field names from m_field/m_method to field and method.  Using reflection with newer versions of jcommander in the classpath throws a runtime exception (and this is in the code path of some fundamental API calls like `GeoWaveStoreFinder.createDataStore()`).  It seems we can account for both potential field names as a backup to provide a bit more flexibility in this regard.