### PR TITLE
Fix incorrect stat queries on Cassandra and DynamoDB

### DIFF
--- a/core/index/src/main/java/org/locationtech/geowave/core/index/ByteArrayUtils.java
+++ b/core/index/src/main/java/org/locationtech/geowave/core/index/ByteArrayUtils.java
@@ -311,6 +311,18 @@ public class ByteArrayUtils {
     return array1.length - array2.length;
   }
 
+  public static boolean startsWith(final byte[] bytes, final byte[] prefix) {
+    if (bytes == null || prefix == null || prefix.length > bytes.length) {
+      return false;
+    }
+    for (int i = 0; i < prefix.length; i++) {
+      if (bytes[i] != prefix[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   public static String getHexString(final byte[] bytes) {
     final StringBuffer str = new StringBuffer();
     for (final byte b : bytes) {

--- a/docs/content/devguide/075-programmatic-api.adoc
+++ b/docs/content/devguide/075-programmatic-api.adoc
@@ -112,6 +112,9 @@ VectorQueryConstraintsFactory constraintsFactory = queryBuilder.constraintsFacto
 
 // Use the constraints factory to create a bounding box constraint
 queryBuilder.constraints(constraintsFactory.cqlConstraints("BBOX(the_geom, -1, -1, 6, 6)"));
+    
+// Only query data from the point type
+queryBuilder.addTypeName(pointTypeAdapter.getTypeName());
 
 // Build the query
 Query<SimpleFeature> query = queryBuilder.build();
@@ -162,8 +165,17 @@ VectorStatisticsQueryBuilder<Object> statisticsQueryBuilder = VectorStatisticsQu
 // Create the query by vector statistics type factory
 QueryByVectorStatisticsTypeFactory queryByStatTypeFactory = statisticsQueryBuilder.factory();
 
+// Create the bounding box query builder
+FieldStatisticsQueryBuilder<Envelope> builder = queryByStatTypeFactory.bbox();
+
+// Specify the geometry field name
+builder.fieldName("the_geom");
+
+// Specify the type name
+builder.dataType(pointTypeAdapter.getTypeName());
+
 // Create the bounding box statistics query
-StatisticsQuery<Envelope> bboxQuery = queryByStatTypeFactory.bbox().build();
+StatisticsQuery<Envelope> bboxQuery = builder.build();
 
 // Aggregate the statistic into a single result
 Envelope bbox = myStore.aggregateStatistics(bboxQuery);

--- a/docs/content/devguide/075-programmatic-api.adoc
+++ b/docs/content/devguide/075-programmatic-api.adoc
@@ -168,9 +168,6 @@ QueryByVectorStatisticsTypeFactory queryByStatTypeFactory = statisticsQueryBuild
 // Create the bounding box query builder
 FieldStatisticsQueryBuilder<Envelope> builder = queryByStatTypeFactory.bbox();
 
-// Specify the geometry field name
-builder.fieldName("the_geom");
-
 // Specify the type name
 builder.dataType(pointTypeAdapter.getTypeName());
 
@@ -180,4 +177,6 @@ StatisticsQuery<Envelope> bboxQuery = builder.build();
 // Aggregate the statistic into a single result
 Envelope bbox = myStore.aggregateStatistics(bboxQuery);
 ----
+
+NOTE: Specifying the type name in the statistics query is optional and serves to filter statistics to the type we are interested in.  If the type name is not supplied, bounding box statistics for all types will be aggregated.
 

--- a/test/src/test/java/org/locationtech/geowave/test/basic/AbstractGeoWaveBasicVectorIT.java
+++ b/test/src/test/java/org/locationtech/geowave/test/basic/AbstractGeoWaveBasicVectorIT.java
@@ -831,18 +831,11 @@ public abstract class AbstractGeoWaveBasicVectorIT extends AbstractGeoWaveIT {
         validateBBox(bboxStat, cachedValue);
         // now make sure it works without giving field name because there is only one geometry field
         // anyways
-        // TODO this doesn't work for cassandra and dynamoDB which expect the stats primary ID to be
-        // an exact match (no prefix scanning without field names like this)
-        if (!(getDataStorePluginOptions().getType().equals(
-            new CassandraStoreFactoryFamily().getDataStoreFactory().getType())
-            || getDataStorePluginOptions().getType().equals(
-                new DynamoDBStoreFactoryFamily().getDataStoreFactory().getType()))) {
-          validateBBox(
-              getDataStorePluginOptions().createDataStore().aggregateStatistics(
-                  VectorStatisticsQueryBuilder.newBuilder().factory().bbox().dataType(
-                      adapter.getTypeName()).build()),
-              cachedValue);
-        }
+        validateBBox(
+            getDataStorePluginOptions().createDataStore().aggregateStatistics(
+                VectorStatisticsQueryBuilder.newBuilder().factory().bbox().dataType(
+                    adapter.getTypeName()).build()),
+            cachedValue);
         Assert.assertTrue(
             "Unable to remove individual stat",
             statsStore.removeStatistics(

--- a/test/src/test/java/org/locationtech/geowave/test/docs/GeoWaveDocumentationExamplesIT.java
+++ b/test/src/test/java/org/locationtech/geowave/test/docs/GeoWaveDocumentationExamplesIT.java
@@ -29,6 +29,7 @@ import org.locationtech.geowave.core.geotime.store.query.api.VectorStatisticsQue
 import org.locationtech.geowave.core.index.persist.Persistable;
 import org.locationtech.geowave.core.store.CloseableIterator;
 import org.locationtech.geowave.core.store.StoreFactoryOptions;
+import org.locationtech.geowave.core.store.adapter.statistics.FieldStatisticsQueryBuilder;
 import org.locationtech.geowave.core.store.api.AggregationQuery;
 import org.locationtech.geowave.core.store.api.DataStore;
 import org.locationtech.geowave.core.store.api.DataStoreFactory;
@@ -173,6 +174,9 @@ public class GeoWaveDocumentationExamplesIT extends AbstractGeoWaveIT {
     // Use the constraints factory to create a bounding box constraint
     queryBuilder.constraints(constraintsFactory.cqlConstraints("BBOX(the_geom, -1, -1, 6, 6)"));
 
+    // Only query data from the point type
+    queryBuilder.addTypeName(pointTypeAdapter.getTypeName());
+
     // Build the query
     Query<SimpleFeature> query = queryBuilder.build();
 
@@ -231,21 +235,26 @@ public class GeoWaveDocumentationExamplesIT extends AbstractGeoWaveIT {
     // Create the query by vector statistics type factory
     QueryByVectorStatisticsTypeFactory queryByStatTypeFactory = statisticsQueryBuilder.factory();
 
+    // Create the bounding box query builder
+    FieldStatisticsQueryBuilder<Envelope> builder = queryByStatTypeFactory.bbox();
+
+    // Specify the geometry field name
+    builder.fieldName("the_geom");
+
+    // Specify the type name
+    builder.dataType(pointTypeAdapter.getTypeName());
+
     // Create the bounding box statistics query
-    StatisticsQuery<Envelope> bboxQuery = queryByStatTypeFactory.bbox().build();
+    StatisticsQuery<Envelope> bboxQuery = builder.build();
 
     // Aggregate the statistic into a single result
     Envelope bbox = myStore.aggregateStatistics(bboxQuery);
     // --------------------------------------------------------------------
     // Verify example
-    // TODO: This query is broken on DynamoDB and Cassandra, once it's fixed, this null check should
-    // be removed.
-    if (bbox != null) {
-      Assert.assertEquals(-5.0, bbox.getMinX(), 0.0001);
-      Assert.assertEquals(-5.0, bbox.getMinY(), 0.0001);
-      Assert.assertEquals(5.0, bbox.getMaxX(), 0.0001);
-      Assert.assertEquals(5.0, bbox.getMaxY(), 0.0001);
-    }
+    Assert.assertEquals(-5.0, bbox.getMinX(), 0.0001);
+    Assert.assertEquals(-5.0, bbox.getMinY(), 0.0001);
+    Assert.assertEquals(5.0, bbox.getMaxX(), 0.0001);
+    Assert.assertEquals(5.0, bbox.getMaxY(), 0.0001);
   }
 
   @Override

--- a/test/src/test/java/org/locationtech/geowave/test/docs/GeoWaveDocumentationExamplesIT.java
+++ b/test/src/test/java/org/locationtech/geowave/test/docs/GeoWaveDocumentationExamplesIT.java
@@ -238,9 +238,6 @@ public class GeoWaveDocumentationExamplesIT extends AbstractGeoWaveIT {
     // Create the bounding box query builder
     FieldStatisticsQueryBuilder<Envelope> builder = queryByStatTypeFactory.bbox();
 
-    // Specify the geometry field name
-    builder.fieldName("the_geom");
-
     // Specify the type name
     builder.dataType(pointTypeAdapter.getTypeName());
 


### PR DESCRIPTION
Fixes #1691 by performing client-side filtering on stat queries when a primary ID is supplied to the metadata query.