### PR TITLE
updated redis version and provided serialization option

### DIFF
--- a/extensions/datastores/redis/pom.xml
+++ b/extensions/datastores/redis/pom.xml
@@ -33,14 +33,6 @@
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-collections4</artifactId>
 		</dependency>
-		<!-- in redisson 3.8.2 this is marked as provided so we have to explicitly 
-			depend on it, in later versions of redisson it is a compile dependency and 
-			we don't have to explicitly depend on it -->
-		<dependency>
-			<groupId>de.ruedigermoeller</groupId>
-			<artifactId>fst</artifactId>
-			<version>2.54</version>
-		</dependency>
 		<dependency>
 			<groupId>com.github.kstyrc</groupId>
 			<artifactId>embedded-redis</artifactId>

--- a/extensions/datastores/redis/src/main/java/org/locationtech/geowave/datastore/redis/operations/DataIndexRangeRead.java
+++ b/extensions/datastores/redis/src/main/java/org/locationtech/geowave/datastore/redis/operations/DataIndexRangeRead.java
@@ -11,6 +11,7 @@ package org.locationtech.geowave.datastore.redis.operations;
 import java.util.Iterator;
 import org.locationtech.geowave.core.store.entities.GeoWaveRow;
 import org.locationtech.geowave.datastore.redis.config.RedisOptions.Compression;
+import org.locationtech.geowave.datastore.redis.config.RedisOptions.Serialization;
 import org.locationtech.geowave.datastore.redis.util.RedisMapWrapper;
 import org.locationtech.geowave.datastore.redis.util.RedisUtils;
 import org.redisson.api.RedissonClient;
@@ -23,6 +24,7 @@ public class DataIndexRangeRead {
 
   protected DataIndexRangeRead(
       final RedissonClient client,
+      final Serialization serialization,
       final Compression compression,
       final String namespace,
       final String typeName,
@@ -30,7 +32,14 @@ public class DataIndexRangeRead {
       final byte[] startDataId,
       final byte[] endDataId,
       final boolean visibilityEnabled) {
-    map = RedisUtils.getDataIndexMap(client, compression, namespace, typeName, visibilityEnabled);
+    map =
+        RedisUtils.getDataIndexMap(
+            client,
+            serialization,
+            compression,
+            namespace,
+            typeName,
+            visibilityEnabled);
     this.adapterId = adapterId;
     this.startDataId = startDataId;
     this.endDataId = endDataId;

--- a/extensions/datastores/redis/src/main/java/org/locationtech/geowave/datastore/redis/operations/DataIndexRead.java
+++ b/extensions/datastores/redis/src/main/java/org/locationtech/geowave/datastore/redis/operations/DataIndexRead.java
@@ -11,6 +11,7 @@ package org.locationtech.geowave.datastore.redis.operations;
 import java.util.Iterator;
 import org.locationtech.geowave.core.store.entities.GeoWaveRow;
 import org.locationtech.geowave.datastore.redis.config.RedisOptions.Compression;
+import org.locationtech.geowave.datastore.redis.config.RedisOptions.Serialization;
 import org.locationtech.geowave.datastore.redis.util.RedisMapWrapper;
 import org.locationtech.geowave.datastore.redis.util.RedisUtils;
 import org.redisson.api.RedissonClient;
@@ -22,13 +23,21 @@ public class DataIndexRead {
 
   protected DataIndexRead(
       final RedissonClient client,
+      final Serialization serialization,
       final Compression compression,
       final String namespace,
       final String typeName,
       final short adapterId,
       final byte[][] dataIds,
       final boolean visibilityEnabled) {
-    map = RedisUtils.getDataIndexMap(client, compression, namespace, typeName, visibilityEnabled);
+    map =
+        RedisUtils.getDataIndexMap(
+            client,
+            serialization,
+            compression,
+            namespace,
+            typeName,
+            visibilityEnabled);
     this.adapterId = adapterId;
     this.dataIds = dataIds;
   }

--- a/extensions/datastores/redis/src/main/java/org/locationtech/geowave/datastore/redis/operations/RedisDataIndexWriter.java
+++ b/extensions/datastores/redis/src/main/java/org/locationtech/geowave/datastore/redis/operations/RedisDataIndexWriter.java
@@ -12,6 +12,7 @@ import org.locationtech.geowave.core.store.entities.GeoWaveRow;
 import org.locationtech.geowave.core.store.entities.GeoWaveValue;
 import org.locationtech.geowave.core.store.operations.RowWriter;
 import org.locationtech.geowave.datastore.redis.config.RedisOptions.Compression;
+import org.locationtech.geowave.datastore.redis.config.RedisOptions.Serialization;
 import org.locationtech.geowave.datastore.redis.util.RedisMapWrapper;
 import org.locationtech.geowave.datastore.redis.util.RedisUtils;
 import org.redisson.api.RedissonClient;
@@ -21,12 +22,20 @@ public class RedisDataIndexWriter implements RowWriter {
 
   public RedisDataIndexWriter(
       final RedissonClient client,
+      final Serialization serialization,
       final Compression compression,
       final String namespace,
       final String typeName,
       final boolean visibilityEnabled) {
     super();
-    map = RedisUtils.getDataIndexMap(client, compression, namespace, typeName, visibilityEnabled);
+    map =
+        RedisUtils.getDataIndexMap(
+            client,
+            serialization,
+            compression,
+            namespace,
+            typeName,
+            visibilityEnabled);
   }
 
   @Override

--- a/extensions/datastores/redis/src/main/java/org/locationtech/geowave/datastore/redis/operations/RedisOperations.java
+++ b/extensions/datastores/redis/src/main/java/org/locationtech/geowave/datastore/redis/operations/RedisOperations.java
@@ -106,6 +106,7 @@ public class RedisOperations implements MapReduceDataStoreOperations {
   public RowWriter createDataIndexWriter(final InternalDataAdapter<?> adapter) {
     return new RedisDataIndexWriter(
         client,
+        options.getSerialization(),
         options.getCompression(),
         gwNamespace,
         adapter.getTypeName(),
@@ -208,6 +209,7 @@ public class RedisOperations implements MapReduceDataStoreOperations {
   public RowReader<GeoWaveRow> createReader(final DataIndexReaderParams readerParams) {
     return new RedisReader<>(
         client,
+        options.getSerialization(),
         options.getCompression(),
         readerParams,
         gwNamespace,
@@ -228,6 +230,7 @@ public class RedisOperations implements MapReduceDataStoreOperations {
     final RedisMapWrapper map =
         RedisUtils.getDataIndexMap(
             client,
+            options.getSerialization(),
             options.getCompression(),
             gwNamespace,
             typeName,

--- a/extensions/datastores/redis/src/main/java/org/locationtech/geowave/datastore/redis/operations/RedisReader.java
+++ b/extensions/datastores/redis/src/main/java/org/locationtech/geowave/datastore/redis/operations/RedisReader.java
@@ -35,6 +35,7 @@ import org.locationtech.geowave.core.store.operations.RowReader;
 import org.locationtech.geowave.core.store.query.filter.ClientVisibilityFilter;
 import org.locationtech.geowave.core.store.util.DataStoreUtils;
 import org.locationtech.geowave.datastore.redis.config.RedisOptions.Compression;
+import org.locationtech.geowave.datastore.redis.config.RedisOptions.Serialization;
 import org.locationtech.geowave.datastore.redis.util.GeoWaveRedisPersistedRow;
 import org.locationtech.geowave.datastore.redis.util.GeoWaveRedisRow;
 import org.locationtech.geowave.datastore.redis.util.RedisUtils;
@@ -69,6 +70,7 @@ public class RedisReader<T> implements RowReader<T> {
 
   public RedisReader(
       final RedissonClient client,
+      final Serialization serialization,
       final Compression compression,
       final DataIndexReaderParams dataIndexReaderParams,
       final String namespace,
@@ -77,6 +79,7 @@ public class RedisReader<T> implements RowReader<T> {
         new Wrapper(
             createIteratorForDataIndexReader(
                 client,
+                serialization,
                 compression,
                 dataIndexReaderParams,
                 namespace,
@@ -216,6 +219,7 @@ public class RedisReader<T> implements RowReader<T> {
 
   private Iterator<GeoWaveRow> createIteratorForDataIndexReader(
       final RedissonClient client,
+      final Serialization serialization,
       final Compression compression,
       final DataIndexReaderParams dataIndexReaderParams,
       final String namespace,
@@ -225,6 +229,7 @@ public class RedisReader<T> implements RowReader<T> {
       retVal =
           new DataIndexRead(
               client,
+              serialization,
               compression,
               namespace,
               dataIndexReaderParams.getInternalAdapterStore().getTypeName(
@@ -236,6 +241,7 @@ public class RedisReader<T> implements RowReader<T> {
       retVal =
           new DataIndexRangeRead(
               client,
+              serialization,
               compression,
               namespace,
               dataIndexReaderParams.getInternalAdapterStore().getTypeName(

--- a/extensions/datastores/redis/src/main/java/org/locationtech/geowave/datastore/redis/util/RedisUtils.java
+++ b/extensions/datastores/redis/src/main/java/org/locationtech/geowave/datastore/redis/util/RedisUtils.java
@@ -26,10 +26,10 @@ import org.locationtech.geowave.core.store.entities.GeoWaveRow;
 import org.locationtech.geowave.core.store.operations.MetadataType;
 import org.locationtech.geowave.core.store.operations.RangeReaderParams;
 import org.locationtech.geowave.datastore.redis.config.RedisOptions.Compression;
+import org.locationtech.geowave.datastore.redis.config.RedisOptions.Serialization;
 import org.redisson.api.RScoredSortedSet;
 import org.redisson.api.RedissonClient;
 import org.redisson.client.protocol.ScoredEntry;
-import org.redisson.codec.FstCodec;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.MultimapBuilder;
 import com.google.common.collect.Streams;
@@ -40,7 +40,6 @@ public class RedisUtils {
   protected static final int MAX_ROWS_FOR_PAGINATION = 1000000;
   public static int REDIS_DEFAULT_MAX_RANGE_DECOMPOSITION = 250;
   public static int REDIS_DEFAULT_AGGREGATION_MAX_RANGE_DECOMPOSITION = 250;
-  private static FstCodec DEFAULT_CODEC = new FstCodec();
 
   public static RScoredSortedSet<GeoWaveMetadata> getMetadataSet(
       final RedissonClient client,
@@ -103,6 +102,7 @@ public class RedisUtils {
 
   public static RedisMapWrapper getDataIndexMap(
       final RedissonClient client,
+      final Serialization serialization,
       final Compression compression,
       final String namespace,
       final String typeName,
@@ -110,7 +110,7 @@ public class RedisUtils {
     return new RedisMapWrapper(
         client,
         getRowSetPrefix(namespace, typeName, DataIndexUtils.DATA_ID_INDEX.getName()),
-        compression.getCodec(DEFAULT_CODEC),
+        compression.getCodec(serialization.getCodec()),
         visibilityEnabled);
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
 		<accumulo.api>1.9</accumulo.api>
 		<bigtable.version>1.2.0</bigtable.version>
 		<cassandra.version>3.11.3</cassandra.version>
-		<redisson.version>3.8.2</redisson.version>
+		<redisson.version>3.11.6</redisson.version>
 		<rocksdb.version>5.15.10</rocksdb.version>
 		<cassandraclient.version>3.5.1</cassandraclient.version>
 		<kuduclient.version>1.8.0</kuduclient.version>


### PR DESCRIPTION
There are several github issues and stackoverflows referring to a memory leak when using FST with redisson. We were seriously running up against this issue and despite what this [1] says, the latest version does not simply resolve it. However, I figure it won't hurt to update to the latest version. We actually only use a provided serialization codec for the data index when secondary indexing is enabled - unfortunately that is our use case. As it stood GeoWave just always uses FST codec for that, which is Redisson's default codec. The only thing GeoWave is serializing for the data index is a `byte[]` so its very straightforward - I'm not sure the advantages/disadvantages of different codec when serializing an object as simple as an array of primitives. My first instinct was to just have our own custom codec just like we have our own codec for every other redisson collection such as the index rows and the metadata rows.  However, maintaining complete backwards compatibility with *any* data store prior to this PR would mean that whatever new code path that circumvents this FST codec issue has to be optional and the FST codec has to be the default behavior.  So then I provided the option for a series of 9 serialization options from this list [2]. However, when running with that there'd be a ClassNotFoundException on a Kryo class from our apps without adding more to the classpath which seemed odd (even though we weren't using Kryo and I was using a Supplier interface so no instantiation happened statically it was just resolving the codec class). Considering this is only to serialize a `byte[]` for secondary indexing and I don't really know. the advantage of using any of these codecs aside from avoiding memory leaks with FST, I backed it down to whats in this PR, using FST by default and the JDK serialization as an option.  We enable JDK serialization through that option and the memory leaks go away so in the end I am sufficiently happy with giving the JDK option, and should we choose to add more, its very easy (without benchmarks I'm not sure to what end though).
[1] https://github.com/redisson/redisson/issues/1927
[2] https://github.com/redisson/redisson/wiki/4.-data-serialization
