### PR TITLE
fix for serialization of regions as enum

### DIFF
--- a/extensions/datastores/dynamodb/src/main/java/org/locationtech/geowave/datastore/dynamodb/config/DynamoDBOptions.java
+++ b/extensions/datastores/dynamodb/src/main/java/org/locationtech/geowave/datastore/dynamodb/config/DynamoDBOptions.java
@@ -191,7 +191,7 @@ public class DynamoDBOptions extends StoreFactoryOptions {
 
     @Override
     public Regions convert(final String regionName) {
-      return Regions.fromName(regionName);
+      return Regions.fromName(regionName.toLowerCase().replaceAll("_", "-"));
     }
   }
 


### PR DESCRIPTION
The Regions enum serializes using toString() which is all uppercase and underscore separated but the Regions.fromValue() uses lower case and hyphen separators.

Signed-off-by: Rich Fecher <rich.fecher@blacklynx.tech>