### PR TITLE
a couple minor conveniences for dynamodb

### DIFF
--- a/extensions/cli/dynamodb-embed/src/main/java/org/locationtech/geowave/datastore/dynamodb/cli/DynamoDBLocal.java
+++ b/extensions/cli/dynamodb-embed/src/main/java/org/locationtech/geowave/datastore/dynamodb/cli/DynamoDBLocal.java
@@ -31,21 +31,38 @@ public class DynamoDBLocal {
   // these need to move to config
   private static final String DYNDB_URL = "https://s3-us-west-2.amazonaws.com/dynamodb-local/";
   private static final String DYNDB_TAR = "dynamodb_local_latest.tar.gz";
-  private static final String HOST_PORT = "8000";
+  public static final int DEFAULT_PORT = 8000;
 
   private static final long EMULATOR_SPINUP_DELAY_MS = 30000L;
-  public static final File DEFAULT_DIR = new File("./target/temp");
+  public static final File DEFAULT_DIR = new File("./temp");
 
   private final File dynLocalDir;
+  private final int port;
   private ExecuteWatchdog watchdog;
 
+  public DynamoDBLocal() {
+    this(null, null);
+  }
+
   public DynamoDBLocal(final String localDir) {
-    if (localDir != null && !localDir.isEmpty()) {
+    this(localDir, null);
+  }
+
+  public DynamoDBLocal(final int port) {
+    this(null, port);
+  }
+
+  public DynamoDBLocal(final String localDir, final Integer port) {
+    if ((localDir != null) && !localDir.isEmpty()) {
       dynLocalDir = new File(localDir);
     } else {
       dynLocalDir = new File(DEFAULT_DIR, "dynamodb");
     }
-
+    if (port != null) {
+      this.port = port;
+    } else {
+      this.port = DEFAULT_PORT;
+    }
     if (!dynLocalDir.exists() && !dynLocalDir.mkdirs()) {
       LOGGER.warn("unable to create directory " + dynLocalDir.getAbsolutePath());
     }
@@ -139,7 +156,7 @@ public class DynamoDBLocal {
     cmdLine.addArgument("-sharedDb");
     cmdLine.addArgument("-inMemory");
     cmdLine.addArgument("-port");
-    cmdLine.addArgument(HOST_PORT);
+    cmdLine.addArgument(Integer.toString(port));
     System.setProperty("aws.accessKeyId", "dummy");
     System.setProperty("aws.secretKey", "dummy");
 

--- a/extensions/cli/dynamodb-embed/src/main/java/org/locationtech/geowave/datastore/dynamodb/cli/RunDynamoDBLocalOptions.java
+++ b/extensions/cli/dynamodb-embed/src/main/java/org/locationtech/geowave/datastore/dynamodb/cli/RunDynamoDBLocalOptions.java
@@ -8,25 +8,36 @@
  */
 package org.locationtech.geowave.datastore.dynamodb.cli;
 
-import java.io.File;
 import java.io.IOException;
 import com.beust.jcommander.Parameter;
 
 public class RunDynamoDBLocalOptions {
   @Parameter(names = {"--directory", "-d"}, description = "The directory to use for DynamoDB")
   private String directory = DynamoDBLocal.DEFAULT_DIR.getPath();
+  @Parameter(
+      names = {"--port", "-p"},
+      description = "The port to use for DynamoDB (defaults to " + DynamoDBLocal.DEFAULT_PORT + ")")
+  private Integer port = DynamoDBLocal.DEFAULT_PORT;
 
 
   public String getDirectory() {
     return directory;
   }
 
-  public void setDirectory(String directory) {
+  public void setDirectory(final String directory) {
     this.directory = directory;
   }
 
 
+  public Integer getPort() {
+    return port;
+  }
+
+  public void setPort(Integer port) {
+    this.port = port;
+  }
+
   public DynamoDBLocal getServer() throws IOException {
-    return new DynamoDBLocal(directory);
+    return new DynamoDBLocal(directory, port);
   }
 }

--- a/extensions/datastores/dynamodb/src/main/java/org/locationtech/geowave/datastore/dynamodb/config/DynamoDBOptions.java
+++ b/extensions/datastores/dynamodb/src/main/java/org/locationtech/geowave/datastore/dynamodb/config/DynamoDBOptions.java
@@ -191,6 +191,9 @@ public class DynamoDBOptions extends StoreFactoryOptions {
 
     @Override
     public Regions convert(final String regionName) {
+      if (regionName == null || regionName.isEmpty()) {
+        return null;
+      }
       return Regions.fromName(regionName.toLowerCase().replaceAll("_", "-"));
     }
   }

--- a/test/src/main/java/org/locationtech/geowave/test/DynamoDBStoreTestEnvironment.java
+++ b/test/src/main/java/org/locationtech/geowave/test/DynamoDBStoreTestEnvironment.java
@@ -8,14 +8,15 @@
  */
 package org.locationtech.geowave.test;
 
+import java.io.File;
 import org.apache.log4j.Logger;
 import org.locationtech.geowave.core.store.GenericStoreFactory;
 import org.locationtech.geowave.core.store.StoreFactoryOptions;
 import org.locationtech.geowave.core.store.api.DataStore;
 import org.locationtech.geowave.datastore.dynamodb.DynamoDBStoreFactoryFamily;
+import org.locationtech.geowave.datastore.dynamodb.cli.DynamoDBLocal;
 import org.locationtech.geowave.datastore.dynamodb.config.DynamoDBOptions;
 import org.locationtech.geowave.test.annotation.GeoWaveTestStore.GeoWaveStoreType;
-import org.locationtech.geowave.datastore.dynamodb.cli.DynamoDBLocal;
 
 public class DynamoDBStoreTestEnvironment extends StoreTestEnvironment {
   private static final GenericStoreFactory<DataStore> STORE_FACTORY =
@@ -33,6 +34,7 @@ public class DynamoDBStoreTestEnvironment extends StoreTestEnvironment {
   private static final Logger LOGGER = Logger.getLogger(DynamoDBStoreTestEnvironment.class);
 
   protected DynamoDBLocal dynamoLocal;
+  public static final File DEFAULT_DIR = new File("./target/temp/dynamodb");
 
   private DynamoDBStoreTestEnvironment() {}
 
@@ -40,7 +42,7 @@ public class DynamoDBStoreTestEnvironment extends StoreTestEnvironment {
   public void setup() {
     // DynamoDB IT's rely on an external dynamo local process
     if (dynamoLocal == null) {
-      dynamoLocal = new DynamoDBLocal(null); // null uses tmp dir
+      dynamoLocal = new DynamoDBLocal(DEFAULT_DIR.getAbsolutePath()); // uses tmp dir
     }
 
     // Make sure we clean up any old processes first


### PR DESCRIPTION
These are both extremely minor enhancements for using dynamodb.  One is just for launching the local instance, to be able to specify port seems like a pretty basic option you would want.  And the other is if region name is not null but is an empty string, it won't use endpoint (it just checks for null in the calling code of this Region, but it really shouldn't try to convert empty strings).  For example, we configure with spring YAML, and there's no way to unset a property  but you can set it to an empty string which seems like it should be sufficient to ignore "region."