### PR TITLE
GWQL grammar update for unconventional type names. Fixes #1707

### DIFF
--- a/extensions/adapters/vector/src/main/antlr4/org/locationtech/geowave/adapter/vector/query/gwql/parse/GWQL.g4
+++ b/extensions/adapters/vector/src/main/antlr4/org/locationtech/geowave/adapter/vector/query/gwql/parse/GWQL.g4
@@ -206,10 +206,20 @@ K_SELECT : S E L E C T;
 K_WHERE : W H E R E;
 
 IDENTIFIER
+	: ESCAPED_IDENTIFIER
+	{
+		String txt = getText();
+		// strip the leading and trailing characters that wrap the identifier when using unconventional naming
+		txt = txt.substring(1, txt.length() - 1); 
+		setText(txt);
+    }
+    | [a-zA-Z_] [a-zA-Z_0-9]* // TODO check: needs more chars in set
+;
+
+ESCAPED_IDENTIFIER
 	: '"' (~'"' | '""')* '"'
 	| '`' (~'`' | '``')* '`'
- 	| '[' ~']'* ']'
- 	| [a-zA-Z_] [a-zA-Z_0-9]* // TODO check: needs more chars in set
+	| '[' ~']'* ']'
 ;
  
 INTEGER

--- a/extensions/adapters/vector/src/test/java/org/locationtech/geowave/adapter/vector/query/gwql/SelectStatementTest.java
+++ b/extensions/adapters/vector/src/test/java/org/locationtech/geowave/adapter/vector/query/gwql/SelectStatementTest.java
@@ -242,4 +242,31 @@ public class SelectStatementTest extends AbstractStatementTest {
     assertEquals("c", selector.columnName());
     assertNull(selectStatement.filter());
   }
+
+  @Test
+  public void testUnconventionalNaming() {
+    final String statement = "SELECT [a-1], `b-2`, \"c-3\" FROM store.[ty-p3]";
+    final Statement gwStatement = GWQLParser.parseStatement(statement);
+    assertTrue(gwStatement instanceof SelectStatement);
+    final SelectStatement selectStatement = (SelectStatement) gwStatement;
+    assertFalse(selectStatement.isAggregation());
+    assertNotNull(selectStatement.typeName());
+    assertEquals("store", selectStatement.typeName().storeName());
+    assertEquals("ty-p3", selectStatement.typeName().typeName());
+    assertNotNull(selectStatement.selectors());
+    assertTrue(selectStatement.selectors().size() == 3);
+    assertTrue(selectStatement.selectors().get(0) instanceof ColumnSelector);
+    ColumnSelector selector = (ColumnSelector) selectStatement.selectors().get(0);
+    assertNull(selector.alias());
+    assertEquals("a-1", selector.columnName());
+    assertTrue(selectStatement.selectors().get(1) instanceof ColumnSelector);
+    selector = (ColumnSelector) selectStatement.selectors().get(1);
+    assertNull(selector.alias());
+    assertEquals("b-2", selector.columnName());
+    assertTrue(selectStatement.selectors().get(2) instanceof ColumnSelector);
+    selector = (ColumnSelector) selectStatement.selectors().get(2);
+    assertNull(selector.alias());
+    assertEquals("c-3", selector.columnName());
+    assertNull(selectStatement.filter());
+  }
 }


### PR DESCRIPTION
Fixes #1707. Update GWQL grammar to support unconventional type names. Added test for unconventional names as well.