### PR TITLE
Fixes for installGdal command

### DIFF
--- a/docs/content/commands/manpages/raster/geowave-installgdal.txt
+++ b/docs/content/commands/manpages/raster/geowave-installgdal.txt
@@ -14,7 +14,7 @@ geowave-raster-installgdal - Install GDAL by downloading native libraries
 [[raster-installgdal-description]]
 ==== DESCRIPTION
 
-This command will download GDAL to a directory.  The directory should be added to the `PATH` and Linux users should set `LD_LIBRARY_PATH` to the directory.  This command is not currently supported on Mac.
+This command installs the version of GDAL that is used by GeoWave.  By default, it is installed to the GeoWave home directory under `lib/utilities/gdal`.  If an alternate directory is provided, it should be added to the `PATH` environment variable for Mac and Windows users, or the `LD_LIBRARY_PATH` environment variable for Linux users.
 
 [[raster-installgdal-options]]
 ==== OPTIONS
@@ -25,7 +25,7 @@ This command will download GDAL to a directory.  The directory should be added t
 [[raster-installgdal-examples]]
 ==== EXAMPLES
 
-Install GDAL libraries on a Windows or Linux machine:
+Install GDAL native libraries:
 
   geowave raster installgdal
 

--- a/docs/content/quickstart-emr/quickstart-emr/020-raster-demo.adoc
+++ b/docs/content/quickstart-emr/quickstart-emr/020-raster-demo.adoc
@@ -10,12 +10,7 @@ In this demo, we will be looking at Band 8 of Landsat raster data around Berlin,
 
 The Landsat 8 extension for GeoWave utilizes GDAL (Geospatial Data Abstraction Library), an image processing library, to process raster data. In order to use GDAL, native libraries need to be installed on the system. More info on GDAL can be found link:http://www.gdal.org[here, window="_blank"].
 
-[WARNING]
-====
-Native libraries for GDAL 1.9.2 on MacOS are not readily available.  This demo is currently only applicable to Windows and Linux platforms.
-====
-
-GeoWave provides a command to install GDAL libraries on both Windows and Linux with the following command:
+GeoWave provides a way to install GDAL libraries with the following command:
 
 [source, bash]
 ----

--- a/docs/content/quickstart/015-raster-demo.adoc
+++ b/docs/content/quickstart/015-raster-demo.adoc
@@ -10,12 +10,7 @@ In this demo, we will be looking at Band 8 of Landsat raster data around Berlin,
 
 The Landsat 8 extension for GeoWave utilizes GDAL (Geospatial Data Abstraction Library), an image processing library, to process raster data. In order to use GDAL, native libraries need to be installed on the system. More info on GDAL can be found link:http://www.gdal.org[here, window="_blank"].
 
-[WARNING]
-====
-Native libraries for GDAL 1.9.2 on MacOS are not readily available.  This demo is currently only applicable to Windows and Linux platforms.
-====
-
-GeoWave provides a command to install GDAL libraries on both Windows and Linux with the following command:
+GeoWave provides a way to install GDAL libraries with the following command:
 
 [source, bash]
 ----

--- a/extensions/adapters/raster/src/main/java/org/locationtech/geowave/adapter/raster/operations/InstallGdalCommand.java
+++ b/extensions/adapters/raster/src/main/java/org/locationtech/geowave/adapter/raster/operations/InstallGdalCommand.java
@@ -8,6 +8,8 @@
  */
 package org.locationtech.geowave.adapter.raster.operations;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.locationtech.geowave.adapter.raster.plugin.gdal.InstallGdal;
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.Command;
@@ -19,13 +21,18 @@ import com.beust.jcommander.Parameters;
 @GeowaveOperation(name = "installgdal", parentOperation = RasterSection.class)
 @Parameters(commandDescription = "Install GDAL by downloading native libraries")
 public class InstallGdalCommand extends DefaultOperation implements Command {
+  private static final String DEFAULT_DOWNLOAD_DIR = "lib/utilities/gdal";
 
   @Parameter(names = "--dir", description = "The download directory", required = false)
-  private String downloadDirectory = "./lib/utilities/gdal";
+  private String downloadDirectory = null;
 
   @Override
   public void execute(final OperationParams params) throws Exception {
+    if (downloadDirectory == null) {
+      final String homeDirectory = System.getProperty("geowave.home", ".");
+      final Path path = Paths.get(homeDirectory, DEFAULT_DOWNLOAD_DIR);
+      downloadDirectory = path.toString();
+    }
     InstallGdal.main(new String[] {downloadDirectory});
   }
-
 }

--- a/extensions/adapters/raster/src/main/java/org/locationtech/geowave/adapter/raster/plugin/gdal/InstallGdal.java
+++ b/extensions/adapters/raster/src/main/java/org/locationtech/geowave/adapter/raster/plugin/gdal/InstallGdal.java
@@ -36,10 +36,6 @@ public class InstallGdal {
       "https://s3.amazonaws.com/geowave/third-party-downloads/gdal";
 
   public static void main(final String[] args) throws IOException {
-    if (isMac()) {
-      LOGGER.warn("Mac OS GDAL native binaries unavailable for download.");
-      return;
-    }
     File gdalDir = null;
     if ((args != null) && (args.length > 0) && (args[0] != null) && !args[0].trim().isEmpty()) {
       gdalDir = new File(args[0]);
@@ -70,11 +66,6 @@ public class InstallGdal {
   }
 
   private static void install(final File gdalDir) throws IOException {
-    if (isMac()) {
-      LOGGER.warn(
-          "Mac OS GDAL native binaries unavailable for download. Run 'brew install --with-swig-java gdal' instead.");
-      return;
-    }
     URL url;
     String file;
     String gdalEnv = System.getProperty(GDAL_ENV);
@@ -84,6 +75,9 @@ public class InstallGdal {
     if (isWindows()) {
       file = "gdal-1.9.2-MSVC2010-x64.zip";
       url = new URL(gdalEnv + "/windows/MSVC2010/" + file);
+    } else if (isMac()) {
+      file = "gdal-1.9.2_macOSX.zip";
+      url = new URL(gdalEnv + "/mac/" + file);
     } else {
       file = "gdal192-CentOS5.8-gcc4.1.2-x86_64.tar.gz";
       url = new URL(gdalEnv + "/linux/" + file);


### PR DESCRIPTION
Relates to #1684. Fixed installGdal to work on macOSX and install relative to proper geowave home directory on all OS's.