### PR TITLE
minor tweak to make format api more consistent

### DIFF
--- a/extensions/datastores/filesystem/src/main/java/org/locationtech/geowave/datastore/filesystem/FileSystemDataFormatter.java
+++ b/extensions/datastores/filesystem/src/main/java/org/locationtech/geowave/datastore/filesystem/FileSystemDataFormatter.java
@@ -82,19 +82,25 @@ public interface FileSystemDataFormatter {
      * When using secondary indexing, this is called for storing the data values.
      *
      * @param fileName the file name
+     * @param typeName the DataTypeAdapter type name
+     * @param indexName the name of this index
      * @param expectsTime whether this index/type anticipates time is encoded in the file name
-     *        (typically raster data only, and not with the secondary data index)
-     *
+     *        (typically raster data only, and not with the secondary data index) *
      * @return an object containing a file name and the expected contents of the file according to
      *         this format
      */
-    FileSystemIndexKey getKey(String fileName, boolean expectsTime);
+    FileSystemIndexKey getKey(
+        String fileName,
+        String typeName,
+        String indexName,
+        boolean expectsTime);
 
     /**
      *
      * @param key the key (as resolved by this file reader's getKey() method)
      * @param fileInfo the file name and contents
-     * @param
+     * @param typeName the DataTypeAdapter type name
+     * @param indexName the name of this index
      * @return a GeoWaveValue to be used for reading the original data back into the system
      */
     GeoWaveValue getValue(

--- a/extensions/datastores/filesystem/src/main/java/org/locationtech/geowave/datastore/filesystem/util/FileSystemIndexTable.java
+++ b/extensions/datastores/filesystem/src/main/java/org/locationtech/geowave/datastore/filesystem/util/FileSystemIndexTable.java
@@ -72,7 +72,7 @@ public class FileSystemIndexTable extends AbstractFileSystemTable {
 
   protected Function<String, FileSystemKey> fileNameToKey() {
     return fileName -> new FileSystemIndexKeyWrapper(
-        formatter.getIndexFormatter().getKey(fileName, requiresTimestamp),
+        formatter.getIndexFormatter().getKey(fileName, typeName, indexName, requiresTimestamp),
         fileName);
   }
 

--- a/extensions/datastores/filesystem/src/main/java/org/locationtech/geowave/datastore/filesystem/util/GeoWaveBinaryDataFormatter.java
+++ b/extensions/datastores/filesystem/src/main/java/org/locationtech/geowave/datastore/filesystem/util/GeoWaveBinaryDataFormatter.java
@@ -160,7 +160,11 @@ public class GeoWaveBinaryDataFormatter implements FileSystemDataFormatterSpi {
     }
 
     @Override
-    public FileSystemIndexKey getKey(final String fileName, final boolean expectsTime) {
+    public FileSystemIndexKey getKey(
+        final String fileName,
+        final String typeName,
+        final String indexName,
+        final boolean expectsTime) {
       int otherBytes = 4;
       final byte[] key = FileSystemUtils.fileNameToKey(fileName);
       final ByteBuffer buf = ByteBuffer.wrap(key);


### PR DESCRIPTION
just added "typeName" and "indexName" to one of the data formatter methods where it was missing.  The default binary formatter doesn't use type name or index name anywhere but its provided in every other method as just additional contextual info that can be helpful and used by the formatter as needed.  The Data Index formatter passes type name to every method and the Index formatter passes index name and type name to every method, again as potentially useful context for the formatter.