### PR TITLE
improved flexibility for directory naming

### DIFF
--- a/extensions/datastores/filesystem/src/main/java/org/locationtech/geowave/datastore/filesystem/FileSystemDataFormatter.java
+++ b/extensions/datastores/filesystem/src/main/java/org/locationtech/geowave/datastore/filesystem/FileSystemDataFormatter.java
@@ -158,7 +158,10 @@ public interface FileSystemDataFormatter {
         final String indexName,
         final String typeName,
         final byte[] partitionKey) {
-      return ByteArrayUtils.byteArrayToString(partitionKey);
+      if ((partitionKey != null) && (partitionKey.length > 0)) {
+        return ByteArrayUtils.byteArrayToString(partitionKey);
+      }
+      return "";
     }
 
     /**
@@ -326,5 +329,9 @@ public interface FileSystemDataFormatter {
   DataIndexFormatter getDataIndexFormatter();
 
   IndexFormatter getIndexFormatter();
+
+  default String getMetadataDirectory() {
+    return "metadata";
+  }
 
 }

--- a/extensions/datastores/filesystem/src/main/java/org/locationtech/geowave/datastore/filesystem/FileSystemDataStoreFactory.java
+++ b/extensions/datastores/filesystem/src/main/java/org/locationtech/geowave/datastore/filesystem/FileSystemDataStoreFactory.java
@@ -29,7 +29,6 @@ public class FileSystemDataStoreFactory extends BaseDataStoreFactory {
     if (!(options instanceof FileSystemOptions)) {
       throw new AssertionError("Expected " + FileSystemOptions.class.getSimpleName());
     }
-
     return new FileSystemDataStore(
         (FileSystemOperations) helper.createOperations(options),
         ((FileSystemOptions) options).getStoreOptions());

--- a/extensions/datastores/filesystem/src/main/java/org/locationtech/geowave/datastore/filesystem/config/FileSystemOptions.java
+++ b/extensions/datastores/filesystem/src/main/java/org/locationtech/geowave/datastore/filesystem/config/FileSystemOptions.java
@@ -33,6 +33,7 @@ public class FileSystemOptions extends StoreFactoryOptions {
           + GeoWaveBinaryDataFormatter.DEFAULT_BINARY_FORMATTER
           + "\" which is a compact geowave serialization.  Use `geowave util filesystem listformats` to see available formats.")
   private String format = "binary";
+
   @ParametersDelegate
   protected BaseDataStoreOptions baseOptions = new BaseDataStoreOptions() {
     @Override

--- a/extensions/datastores/filesystem/src/main/java/org/locationtech/geowave/datastore/filesystem/operations/FileSystemDataIndexWriter.java
+++ b/extensions/datastores/filesystem/src/main/java/org/locationtech/geowave/datastore/filesystem/operations/FileSystemDataIndexWriter.java
@@ -21,9 +21,8 @@ public class FileSystemDataIndexWriter implements RowWriter {
   public FileSystemDataIndexWriter(
       final FileSystemClient client,
       final short adapterId,
-      final String typeName,
-      final String format) {
-    table = FileSystemUtils.getDataIndexTable(client, adapterId, typeName, format);
+      final String typeName) {
+    table = FileSystemUtils.getDataIndexTable(client, adapterId, typeName);
   }
 
   @Override

--- a/extensions/datastores/filesystem/src/main/java/org/locationtech/geowave/datastore/filesystem/operations/FileSystemQueryExecution.java
+++ b/extensions/datastores/filesystem/src/main/java/org/locationtech/geowave/datastore/filesystem/operations/FileSystemQueryExecution.java
@@ -126,7 +126,6 @@ public class FileSystemQueryExecution<T> {
         typeName,
         indexName,
         partitionKey,
-        format,
         groupByRowAndSortByTimePair.getRight());
   }
 

--- a/extensions/datastores/filesystem/src/main/java/org/locationtech/geowave/datastore/filesystem/operations/FileSystemRowDeleter.java
+++ b/extensions/datastores/filesystem/src/main/java/org/locationtech/geowave/datastore/filesystem/operations/FileSystemRowDeleter.java
@@ -32,19 +32,16 @@ public class FileSystemRowDeleter implements RowDeleter {
     private final String typeName;
     private final String indexName;
     private final byte[] partition;
-    private final String format;
 
     public CacheKey(
         final short adapterId,
         final String typeName,
         final String indexName,
-        final byte[] partition,
-        final String format) {
+        final byte[] partition) {
       this.adapterId = adapterId;
       this.typeName = typeName;
       this.indexName = indexName;
       this.partition = partition;
-      this.format = format;
     }
 
   }
@@ -55,19 +52,16 @@ public class FileSystemRowDeleter implements RowDeleter {
   private final PersistentAdapterStore adapterStore;
   private final InternalAdapterStore internalAdapterStore;
   private final String indexName;
-  private final String format;
 
   public FileSystemRowDeleter(
       final FileSystemClient client,
       final PersistentAdapterStore adapterStore,
       final InternalAdapterStore internalAdapterStore,
-      final String indexName,
-      final String format) {
+      final String indexName) {
     this.client = client;
     this.adapterStore = adapterStore;
     this.internalAdapterStore = internalAdapterStore;
     this.indexName = indexName;
-    this.format = format;
   }
 
   @Override
@@ -82,7 +76,6 @@ public class FileSystemRowDeleter implements RowDeleter {
         cacheKey.typeName,
         cacheKey.indexName,
         cacheKey.partition,
-        cacheKey.format,
         FileSystemUtils.isSortByTime(adapterStore.getAdapter(cacheKey.adapterId)));
   }
 
@@ -94,8 +87,7 @@ public class FileSystemRowDeleter implements RowDeleter {
                 row.getAdapterId(),
                 internalAdapterStore.getTypeName(row.getAdapterId()),
                 indexName,
-                row.getPartitionKey(),
-                format));
+                row.getPartitionKey()));
     if (row instanceof GeoWaveRowImpl) {
       final GeoWaveKey key = ((GeoWaveRowImpl) row).getKey();
       if (key instanceof FileSystemRow) {

--- a/extensions/datastores/filesystem/src/main/java/org/locationtech/geowave/datastore/filesystem/operations/FileSystemWriter.java
+++ b/extensions/datastores/filesystem/src/main/java/org/locationtech/geowave/datastore/filesystem/operations/FileSystemWriter.java
@@ -28,20 +28,17 @@ public class FileSystemWriter implements RowWriter {
   private final LoadingCache<ByteArray, FileSystemIndexTable> tableCache =
       Caffeine.newBuilder().build(partitionKey -> getTable(partitionKey.getBytes()));
   private final boolean isTimestampRequired;
-  private final String format;
 
   public FileSystemWriter(
       final FileSystemClient client,
       final short adapterId,
       final String typeName,
       final String indexName,
-      final String format,
       final boolean isTimestampRequired) {
     this.client = client;
     this.adapterId = adapterId;
     this.typeName = typeName;
     this.indexName = indexName;
-    this.format = format;
     this.isTimestampRequired = isTimestampRequired;
   }
 
@@ -52,7 +49,6 @@ public class FileSystemWriter implements RowWriter {
         typeName,
         indexName,
         partitionKey,
-        format,
         isTimestampRequired);
   }
 

--- a/extensions/datastores/filesystem/src/main/java/org/locationtech/geowave/datastore/filesystem/util/FileSystemDataIndexTable.java
+++ b/extensions/datastores/filesystem/src/main/java/org/locationtech/geowave/datastore/filesystem/util/FileSystemDataIndexTable.java
@@ -10,7 +10,6 @@ package org.locationtech.geowave.datastore.filesystem.util;
 
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Objects;
 import org.apache.commons.lang3.tuple.Pair;
@@ -34,7 +33,9 @@ public class FileSystemDataIndexTable extends AbstractFileSystemTable {
       final boolean visibilityEnabled) throws IOException {
     super(adapterId, typeName, format, visibilityEnabled);
     setTableDirectory(
-        Paths.get(subDirectory, formatter.getDataIndexFormatter().getDirectoryName(typeName)));
+        FileSystemUtils.getSubdirectory(
+            subDirectory,
+            formatter.getDataIndexFormatter().getDirectoryName(typeName)));
   }
 
   public synchronized void add(final byte[] dataId, final GeoWaveValue value) {

--- a/extensions/datastores/filesystem/src/main/java/org/locationtech/geowave/datastore/filesystem/util/FileSystemIndexTable.java
+++ b/extensions/datastores/filesystem/src/main/java/org/locationtech/geowave/datastore/filesystem/util/FileSystemIndexTable.java
@@ -10,7 +10,6 @@ package org.locationtech.geowave.datastore.filesystem.util;
 
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.function.Function;
@@ -47,16 +46,11 @@ public class FileSystemIndexTable extends AbstractFileSystemTable {
     this.partitionKey = partitionKey;
     final IndexFormatter indexFormatter = formatter.getIndexFormatter();
 
-    if ((partitionKey != null) && (partitionKey.length > 0)) {
-      setTableDirectory(
-          Paths.get(
-              subDirectory,
-              indexFormatter.getDirectoryName(indexName, typeName),
-              indexFormatter.getPartitionDirectoryName(indexName, typeName, partitionKey)));
-    } else {
-      setTableDirectory(
-          Paths.get(subDirectory, indexFormatter.getDirectoryName(indexName, typeName)));
-    }
+    setTableDirectory(
+        FileSystemUtils.getSubdirectory(
+            subDirectory,
+            indexFormatter.getDirectoryName(indexName, typeName),
+            indexFormatter.getPartitionDirectoryName(indexName, typeName, partitionKey)));
   }
 
   public void delete(final byte[] sortKey, final byte[] dataId) {

--- a/extensions/datastores/filesystem/src/main/java/org/locationtech/geowave/datastore/filesystem/util/GeoWaveBinaryDataFormatter.java
+++ b/extensions/datastores/filesystem/src/main/java/org/locationtech/geowave/datastore/filesystem/util/GeoWaveBinaryDataFormatter.java
@@ -46,6 +46,7 @@ public class GeoWaveBinaryDataFormatter implements FileSystemDataFormatterSpi {
   }
 
   private static class BinaryFormatter implements FileSystemDataFormatter {
+
     private final DataIndexFormatter dataIndexFormatter;
     private final IndexFormatter indexFormatter;
 


### PR DESCRIPTION
needed to add a quick fix on line 152 of FileSystemOperations (one of the deleteAll methods didn't use subdirectory in creating the path).

So.. in addition to that small fix I did a little cleanup:
1) added `format` to the "client" so that it didn't need to be redundantly passed all over the place
2) allowed for directories supplied by the formatter plugin to be null or empty strings in which case it wouldn't add a subdirectory to the path.
3) allowed for the formatter to also define the directory of metadata (previously hard-coded to "metadata"