### PR TITLE
GEOWAVE-1731: update jcommander to v1.78

### DIFF
--- a/analytics/mapreduce/src/main/java/org/locationtech/geowave/analytic/mapreduce/operations/AnalyticSection.java
+++ b/analytics/mapreduce/src/main/java/org/locationtech/geowave/analytic/mapreduce/operations/AnalyticSection.java
@@ -10,10 +10,10 @@ package org.locationtech.geowave.analytic.mapreduce.operations;
 
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.DefaultOperation;
-import org.locationtech.geowave.core.cli.operations.GeowaveTopLevelSection;
+import org.locationtech.geowave.core.cli.operations.GeoWaveTopLevelSection;
 import com.beust.jcommander.Parameters;
 
-@GeowaveOperation(name = "analytic", parentOperation = GeowaveTopLevelSection.class)
+@GeowaveOperation(name = "analytic", parentOperation = GeoWaveTopLevelSection.class)
 @Parameters(commandDescription = "Commands to run analytics on GeoWave data sets")
 public class AnalyticSection extends DefaultOperation {
 }

--- a/analytics/mapreduce/src/main/java/org/locationtech/geowave/analytic/mapreduce/operations/DBScanCommand.java
+++ b/analytics/mapreduce/src/main/java/org/locationtech/geowave/analytic/mapreduce/operations/DBScanCommand.java
@@ -107,7 +107,7 @@ public class DBScanCommand extends ServiceEnabledCommand<Void> {
     }
 
     final StoreLoader inputStoreLoader = new StoreLoader(inputStoreName);
-    if (!inputStoreLoader.loadFromConfig(configFile)) {
+    if (!inputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
     }
     inputStoreOptions = inputStoreLoader.getDataStorePlugin();

--- a/analytics/mapreduce/src/main/java/org/locationtech/geowave/analytic/mapreduce/operations/KdeCommand.java
+++ b/analytics/mapreduce/src/main/java/org/locationtech/geowave/analytic/mapreduce/operations/KdeCommand.java
@@ -67,14 +67,14 @@ public class KdeCommand extends ServiceEnabledCommand<Void> {
     Index outputPrimaryIndex = null;
 
     final StoreLoader inputStoreLoader = new StoreLoader(inputStore);
-    if (!inputStoreLoader.loadFromConfig(configFile)) {
+    if (!inputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
     }
     inputStoreOptions = inputStoreLoader.getDataStorePlugin();
 
     // Attempt to load output store.
     final StoreLoader outputStoreLoader = new StoreLoader(outputStore);
-    if (!outputStoreLoader.loadFromConfig(configFile)) {
+    if (!outputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + outputStoreLoader.getStoreName());
     }
     outputStoreOptions = outputStoreLoader.getDataStorePlugin();
@@ -83,7 +83,7 @@ public class KdeCommand extends ServiceEnabledCommand<Void> {
       final String outputIndex = kdeOptions.getOutputIndex();
 
       // Load the Indices
-      List<Index> outputIndices =
+      final List<Index> outputIndices =
           DataStoreUtils.loadIndices(outputStoreLoader.createIndexStore(), outputIndex);
 
       for (final Index primaryIndex : outputIndices) {

--- a/analytics/mapreduce/src/main/java/org/locationtech/geowave/analytic/mapreduce/operations/KmeansJumpCommand.java
+++ b/analytics/mapreduce/src/main/java/org/locationtech/geowave/analytic/mapreduce/operations/KmeansJumpCommand.java
@@ -73,7 +73,7 @@ public class KmeansJumpCommand extends DefaultOperation implements Command {
     }
 
     final StoreLoader inputStoreLoader = new StoreLoader(inputStoreName);
-    if (!inputStoreLoader.loadFromConfig(configFile)) {
+    if (!inputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
     }
     inputStoreOptions = inputStoreLoader.getDataStorePlugin();

--- a/analytics/mapreduce/src/main/java/org/locationtech/geowave/analytic/mapreduce/operations/KmeansParallelCommand.java
+++ b/analytics/mapreduce/src/main/java/org/locationtech/geowave/analytic/mapreduce/operations/KmeansParallelCommand.java
@@ -73,7 +73,7 @@ public class KmeansParallelCommand extends DefaultOperation implements Command {
     }
 
     final StoreLoader inputStoreLoader = new StoreLoader(inputStoreName);
-    if (!inputStoreLoader.loadFromConfig(configFile)) {
+    if (!inputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
     }
     inputStoreOptions = inputStoreLoader.getDataStorePlugin();

--- a/analytics/mapreduce/src/main/java/org/locationtech/geowave/analytic/mapreduce/operations/NearestNeighborCommand.java
+++ b/analytics/mapreduce/src/main/java/org/locationtech/geowave/analytic/mapreduce/operations/NearestNeighborCommand.java
@@ -107,7 +107,7 @@ public class NearestNeighborCommand extends ServiceEnabledCommand<Void> {
     }
 
     final StoreLoader inputStoreLoader = new StoreLoader(inputStoreName);
-    if (!inputStoreLoader.loadFromConfig(configFile)) {
+    if (!inputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
     }
     inputStoreOptions = inputStoreLoader.getDataStorePlugin();

--- a/analytics/spark/src/main/java/org/locationtech/geowave/analytic/spark/kde/operations/KDESparkCommand.java
+++ b/analytics/spark/src/main/java/org/locationtech/geowave/analytic/spark/kde/operations/KDESparkCommand.java
@@ -61,13 +61,13 @@ public class KDESparkCommand extends ServiceEnabledCommand<Void> implements Comm
     final File configFile = getGeoWaveConfigFile(params);
 
     final StoreLoader inputStoreLoader = new StoreLoader(inputStoreName);
-    if (!inputStoreLoader.loadFromConfig(configFile)) {
+    if (!inputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find input store: " + inputStoreLoader.getStoreName());
     }
     inputDataStore = inputStoreLoader.getDataStorePlugin();
 
     final StoreLoader outputStoreLoader = new StoreLoader(outputStoreName);
-    if (!outputStoreLoader.loadFromConfig(configFile)) {
+    if (!outputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find output store: " + outputStoreLoader.getStoreName());
     }
     outputDataStore = outputStoreLoader.getDataStorePlugin();
@@ -91,7 +91,7 @@ public class KDESparkCommand extends ServiceEnabledCommand<Void> implements Comm
       final String outputIndex = kdeSparkOptions.getOutputIndex();
 
       // Load the Indices
-      List<Index> outputIndices =
+      final List<Index> outputIndices =
           DataStoreUtils.loadIndices(outputStoreLoader.createIndexStore(), outputIndex);
 
       for (final Index primaryIndex : outputIndices) {

--- a/analytics/spark/src/main/java/org/locationtech/geowave/analytic/spark/kmeans/operations/KmeansSparkCommand.java
+++ b/analytics/spark/src/main/java/org/locationtech/geowave/analytic/spark/kmeans/operations/KmeansSparkCommand.java
@@ -63,13 +63,13 @@ public class KmeansSparkCommand extends ServiceEnabledCommand<Void> implements C
     final File configFile = getGeoWaveConfigFile(params);
 
     final StoreLoader inputStoreLoader = new StoreLoader(inputStoreName);
-    if (!inputStoreLoader.loadFromConfig(configFile)) {
+    if (!inputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find input store: " + inputStoreLoader.getStoreName());
     }
     inputDataStore = inputStoreLoader.getDataStorePlugin();
 
     final StoreLoader outputStoreLoader = new StoreLoader(outputStoreName);
-    if (!outputStoreLoader.loadFromConfig(configFile)) {
+    if (!outputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find output store: " + outputStoreLoader.getStoreName());
     }
     outputDataStore = outputStoreLoader.getDataStorePlugin();

--- a/analytics/spark/src/main/java/org/locationtech/geowave/analytic/spark/resize/ResizeSparkCommand.java
+++ b/analytics/spark/src/main/java/org/locationtech/geowave/analytic/spark/resize/ResizeSparkCommand.java
@@ -66,14 +66,14 @@ public class ResizeSparkCommand extends DefaultOperation implements Command {
 
     // Attempt to load input store.
     final StoreLoader inputStoreLoader = new StoreLoader(inputStoreName);
-    if (!inputStoreLoader.loadFromConfig(configFile)) {
+    if (!inputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
     }
     inputStoreOptions = inputStoreLoader.getDataStorePlugin();
 
     // Attempt to load output store.
     final StoreLoader outputStoreLoader = new StoreLoader(outputStoreName);
-    if (!outputStoreLoader.loadFromConfig(configFile)) {
+    if (!outputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + outputStoreLoader.getStoreName());
     }
     outputStoreOptions = outputStoreLoader.getDataStorePlugin();

--- a/analytics/spark/src/main/java/org/locationtech/geowave/analytic/spark/spatial/operations/SpatialJoinCommand.java
+++ b/analytics/spark/src/main/java/org/locationtech/geowave/analytic/spark/spatial/operations/SpatialJoinCommand.java
@@ -30,6 +30,7 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.ParametersDelegate;
+import com.beust.jcommander.internal.Console;
 
 @GeowaveOperation(name = "spatialjoin", parentOperation = AnalyticSection.class)
 @Parameters(commandDescription = "Spatial join using Spark ")
@@ -38,11 +39,15 @@ public class SpatialJoinCommand extends ServiceEnabledCommand<Void> {
   private List<String> parameters = new ArrayList<>();
 
   @ParametersDelegate
-  private final SpatialJoinCmdOptions spatialJoinOptions = new SpatialJoinCmdOptions();
+  private SpatialJoinCmdOptions spatialJoinOptions = new SpatialJoinCmdOptions();
 
   DataStorePluginOptions leftDataStore = null;
   DataStorePluginOptions rightDataStore = null;
   DataStorePluginOptions outputDataStore = null;
+
+  public void setParameters(final List<String> parameters) {
+    this.parameters = parameters;
+  }
 
   @Override
   public void execute(final OperationParams params) throws Exception {
@@ -52,6 +57,10 @@ public class SpatialJoinCommand extends ServiceEnabledCommand<Void> {
           "Requires arguments: <left storename> <right storename> <output storename>");
     }
     computeResults(params);
+  }
+
+  public void setSpatialJoinOptions(final SpatialJoinCmdOptions spatialJoinOptions) {
+    this.spatialJoinOptions = spatialJoinOptions;
   }
 
   @Override
@@ -65,15 +74,15 @@ public class SpatialJoinCommand extends ServiceEnabledCommand<Void> {
 
     // Attempt to load stores.
     if (leftDataStore == null) {
-      leftDataStore = loadStore(leftStoreName, configFile);
+      leftDataStore = loadStore(leftStoreName, configFile, params.getConsole());
     }
 
     if (rightDataStore == null) {
-      rightDataStore = loadStore(rightStoreName, configFile);
+      rightDataStore = loadStore(rightStoreName, configFile, params.getConsole());
     }
 
     if (outputDataStore == null) {
-      outputDataStore = loadStore(outputStoreName, configFile);
+      outputDataStore = loadStore(outputStoreName, configFile, params.getConsole());
     }
 
     // Save a reference to the output store in the property management.
@@ -134,9 +143,12 @@ public class SpatialJoinCommand extends ServiceEnabledCommand<Void> {
     return null;
   }
 
-  private DataStorePluginOptions loadStore(final String storeName, final File configFile) {
+  private DataStorePluginOptions loadStore(
+      final String storeName,
+      final File configFile,
+      final Console console) {
     final StoreLoader storeLoader = new StoreLoader(storeName);
-    if (!storeLoader.loadFromConfig(configFile)) {
+    if (!storeLoader.loadFromConfig(configFile, console)) {
       throw new ParameterException("Cannot find left store: " + storeLoader.getStoreName());
     }
     return storeLoader.getDataStorePlugin();

--- a/core/cli/src/main/java/org/locationtech/geowave/core/cli/GeoWaveMain.java
+++ b/core/cli/src/main/java/org/locationtech/geowave/core/cli/GeoWaveMain.java
@@ -11,7 +11,7 @@ package org.locationtech.geowave.core.cli;
 import org.locationtech.geowave.core.cli.api.Command;
 import org.locationtech.geowave.core.cli.api.Operation;
 import org.locationtech.geowave.core.cli.operations.ExplainCommand;
-import org.locationtech.geowave.core.cli.operations.GeowaveTopLevelSection;
+import org.locationtech.geowave.core.cli.operations.GeoWaveTopLevelSection;
 import org.locationtech.geowave.core.cli.operations.HelpCommand;
 import org.locationtech.geowave.core.cli.parser.CommandLineOperationParams;
 import org.locationtech.geowave.core.cli.parser.OperationParser;
@@ -31,7 +31,7 @@ public class GeoWaveMain {
   public static void main(final String[] args) {
     // Take an initial stab at running geowave with the given arguments.
     final OperationParser parser = new OperationParser(prepRegistry());
-    final CommandLineOperationParams params = parser.parse(GeowaveTopLevelSection.class, args);
+    final CommandLineOperationParams params = parser.parse(GeoWaveTopLevelSection.class, args);
 
     // Run the command if no issue.
     // successCode == 1 means that prepare returned false
@@ -48,7 +48,7 @@ public class GeoWaveMain {
     if (params.getSuccessCode() < 0) {
       doHelp(params);
       LOGGER.debug(params.getSuccessMessage(), params.getSuccessException());
-      JCommander.getConsole().println("\n" + params.getSuccessMessage());
+      params.getCommander().getConsole().println("\n" + params.getSuccessMessage());
     } else if ((params.getSuccessCode() == 0) && !params.isCommandPresent()) {
       doHelp(params);
     }
@@ -94,7 +94,7 @@ public class GeoWaveMain {
 
     final OperationEntry explainCommand = registry.getOperation(ExplainCommand.class);
     final OperationEntry helpCommand = registry.getOperation(HelpCommand.class);
-    final OperationEntry topLevel = registry.getOperation(GeowaveTopLevelSection.class);
+    final OperationEntry topLevel = registry.getOperation(GeoWaveTopLevelSection.class);
 
     // Special processing for "HelpSection". This special section will be
     // added as a child to

--- a/core/cli/src/main/java/org/locationtech/geowave/core/cli/VersionUtils.java
+++ b/core/cli/src/main/java/org/locationtech/geowave/core/cli/VersionUtils.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.beust.jcommander.JCommander;
+import com.beust.jcommander.internal.Console;
 
 public class VersionUtils {
   private static final Logger LOGGER = LoggerFactory.getLogger(VersionUtils.class);
@@ -24,7 +24,7 @@ public class VersionUtils {
   private static final String BUILD_PROPERTIES_FILE_NAME = "build.properties";
   private static final String VERSION_PROPERTY_KEY = "project.version";
 
-  public static Properties getBuildProperties() {
+  public static Properties getBuildProperties(final Console console) {
 
     final Properties props = new Properties();
     try (InputStream stream =
@@ -37,19 +37,30 @@ public class VersionUtils {
       return props;
     } catch (final IOException e) {
       LOGGER.warn("Cannot read GeoWave build properties to show version information", e);
-      JCommander.getConsole().print(
-          "Cannot read GeoWave build properties to show version information: " + e.getMessage());
+
+      if (console != null) {
+        console.println(
+            "Cannot read GeoWave build properties to show version information: " + e.getMessage());
+      }
     }
     return props;
   }
 
   public static String getVersion() {
-    return getBuildProperties().getProperty(VERSION_PROPERTY_KEY);
+    return getVersion(null);
+  }
+
+  public static String getVersion(final Console console) {
+    return getBuildProperties(console).getProperty(VERSION_PROPERTY_KEY);
   }
 
   public static List<String> getVersionInfo() {
+    return getVersionInfo(null);
+  }
+
+  public static List<String> getVersionInfo(final Console console) {
     final List<String> buildAndPropertyList =
-        Arrays.asList(getBuildProperties().toString().split(","));
+        Arrays.asList(getBuildProperties(console).toString().split(","));
     Collections.sort(buildAndPropertyList.subList(1, buildAndPropertyList.size()));
     return buildAndPropertyList;
   }
@@ -62,10 +73,10 @@ public class VersionUtils {
     return str.toString();
   }
 
-  public static void printVersionInfo() {
-    final List<String> buildAndPropertyList = getVersionInfo();
+  public static void printVersionInfo(final Console console) {
+    final List<String> buildAndPropertyList = getVersionInfo(console);
     for (final String str : buildAndPropertyList) {
-      JCommander.getConsole().println(str);
+      console.println(str);
     }
   }
 }

--- a/core/cli/src/main/java/org/locationtech/geowave/core/cli/api/DefaultOperation.java
+++ b/core/cli/src/main/java/org/locationtech/geowave/core/cli/api/DefaultOperation.java
@@ -72,7 +72,7 @@ public abstract class DefaultOperation implements Operation {
 
     if (getGeoWaveConfigFile(params) == null) {
       // if file does not exist
-      setGeoWaveConfigFile(ConfigOptions.getDefaultPropertyFile());
+      setGeoWaveConfigFile(ConfigOptions.getDefaultPropertyFile(params.getConsole()));
       setDefaultConfigProperties(params);
     }
 
@@ -184,7 +184,7 @@ public abstract class DefaultOperation implements Operation {
       final DefaultConfigProviderSpi defaultPropertiesProvider = defaultPropertiesProviders.next();
       defaultProperties.putAll(defaultPropertiesProvider.getDefaultConfig());
     }
-    ConfigOptions.writeProperties(getGeoWaveConfigFile(), defaultProperties);
+    ConfigOptions.writeProperties(getGeoWaveConfigFile(), defaultProperties, params.getConsole());
   }
 
   @Override

--- a/core/cli/src/main/java/org/locationtech/geowave/core/cli/api/OperationParams.java
+++ b/core/cli/src/main/java/org/locationtech/geowave/core/cli/api/OperationParams.java
@@ -9,6 +9,7 @@
 package org.locationtech.geowave.core.cli.api;
 
 import java.util.Map;
+import com.beust.jcommander.internal.Console;
 
 /**
  * This arguments are used to allow sections and commands to modify how arguments are parsed during
@@ -25,4 +26,11 @@ public interface OperationParams {
    * @return Key value pairs for contextual information during command parsing.
    */
   Map<String, Object> getContext();
+
+  /**
+   * Get the console to print commandline messages
+   * 
+   * @return the console
+   */
+  Console getConsole();
 }

--- a/core/cli/src/main/java/org/locationtech/geowave/core/cli/converters/GeoWaveBaseConverter.java
+++ b/core/cli/src/main/java/org/locationtech/geowave/core/cli/converters/GeoWaveBaseConverter.java
@@ -49,7 +49,7 @@ public abstract class GeoWaveBaseConverter<T> extends BaseConverter<T> {
     if (new ConfigOptions().getConfigFile() != null) {
       propertyFile = new File(new ConfigOptions().getConfigFile());
     } else {
-      propertyFile = ConfigOptions.getDefaultPropertyFile();
+      propertyFile = ConfigOptions.getDefaultPropertyFile(getConsole());
     }
     if ((propertyFile != null) && propertyFile.exists()) {
       setProperties(ConfigOptions.loadProperties(propertyFile));

--- a/core/cli/src/main/java/org/locationtech/geowave/core/cli/converters/PasswordConverter.java
+++ b/core/cli/src/main/java/org/locationtech/geowave/core/cli/converters/PasswordConverter.java
@@ -183,6 +183,6 @@ public class PasswordConverter extends GeoWaveBaseConverter<String> {
   }
 
   protected File getGeoWaveConfigFile() {
-    return ConfigOptions.getDefaultPropertyFile();
+    return ConfigOptions.getDefaultPropertyFile(getConsole());
   }
 }

--- a/core/cli/src/main/java/org/locationtech/geowave/core/cli/operations/ExplainCommand.java
+++ b/core/cli/src/main/java/org/locationtech/geowave/core/cli/operations/ExplainCommand.java
@@ -23,7 +23,7 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterDescription;
 import com.beust.jcommander.Parameters;
 
-@GeowaveOperation(name = "explain", parentOperation = GeowaveTopLevelSection.class)
+@GeowaveOperation(name = "explain", parentOperation = GeoWaveTopLevelSection.class)
 @Parameters(
     commandDescription = "See what arguments are missing and "
         + "what values will be used for GeoWave commands")
@@ -76,7 +76,7 @@ public class ExplainCommand extends DefaultOperation implements Command {
       commander = commander.getCommands().get(nextCommand);
     }
 
-    JCommander.getConsole().println(builder.toString().trim());
+    params.getConsole().println(builder.toString().trim());
   }
 
   /**
@@ -158,7 +158,7 @@ public class ExplainCommand extends DefaultOperation implements Command {
   public static StringBuilder explainMainParameter(final JCommander commander) {
     final StringBuilder builder = new StringBuilder();
 
-    final ParameterDescription mainParameter = commander.getMainParameter();
+    final ParameterDescription mainParameter = commander.getMainParameterValue();
 
     // Output the main parameter.
     if (mainParameter != null) {

--- a/core/cli/src/main/java/org/locationtech/geowave/core/cli/operations/GeoWaveTopLevelSection.java
+++ b/core/cli/src/main/java/org/locationtech/geowave/core/cli/operations/GeoWaveTopLevelSection.java
@@ -21,7 +21,7 @@ import com.beust.jcommander.ParametersDelegate;
 
 @GeowaveOperation(name = "geowave")
 @Parameters(commandDescription = "This is the top level section.")
-public class GeowaveTopLevelSection extends DefaultOperation {
+public class GeoWaveTopLevelSection extends DefaultOperation {
   @Parameter(names = "--debug", description = "Verbose output")
   private Boolean verboseFlag;
 
@@ -48,7 +48,7 @@ public class GeowaveTopLevelSection extends DefaultOperation {
 
     // Print out the version info if requested.
     if (Boolean.TRUE.equals(versionFlag)) {
-      VersionUtils.printVersionInfo();
+      VersionUtils.printVersionInfo(inputParams.getConsole());
       // Do not continue
       return false;
     }

--- a/core/cli/src/main/java/org/locationtech/geowave/core/cli/operations/HelpCommand.java
+++ b/core/cli/src/main/java/org/locationtech/geowave/core/cli/operations/HelpCommand.java
@@ -27,7 +27,7 @@ import org.locationtech.geowave.core.cli.spi.OperationRegistry;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameters;
 
-@GeowaveOperation(name = "help", parentOperation = GeowaveTopLevelSection.class)
+@GeowaveOperation(name = "help", parentOperation = GeoWaveTopLevelSection.class)
 @Parameters(commandDescription = "Get descriptions of arguments for any GeoWave command")
 public class HelpCommand extends DefaultOperation implements Command {
 
@@ -61,7 +61,7 @@ public class HelpCommand extends DefaultOperation implements Command {
     }
 
     if (lastOperation == null) {
-      lastOperation = registry.getOperation(GeowaveTopLevelSection.class).createInstance();
+      lastOperation = registry.getOperation(GeoWaveTopLevelSection.class).createInstance();
     }
     if (lastOperation != null) {
       final String usage = lastOperation.usage();
@@ -91,7 +91,7 @@ public class HelpCommand extends DefaultOperation implements Command {
 
         final String programName = StringUtils.join(nameArray, " ");
         jc.setProgramName(programName);
-        jc.usage(builder);
+        jc.getUsageFormatter().usage(builder);
 
         // Trim excess newlines.
         final String operations = builder.toString().trim();

--- a/core/cli/src/main/java/org/locationtech/geowave/core/cli/operations/TopLevelOperationProvider.java
+++ b/core/cli/src/main/java/org/locationtech/geowave/core/cli/operations/TopLevelOperationProvider.java
@@ -13,7 +13,7 @@ import org.locationtech.geowave.core.cli.spi.CLIOperationProviderSpi;
 public class TopLevelOperationProvider implements CLIOperationProviderSpi {
 
   private static final Class<?>[] BASE_OPERATIONS =
-      new Class<?>[] {GeowaveTopLevelSection.class, ExplainCommand.class, HelpCommand.class};
+      new Class<?>[] {GeoWaveTopLevelSection.class, ExplainCommand.class, HelpCommand.class};
 
   @Override
   public Class<?>[] getOperations() {

--- a/core/cli/src/main/java/org/locationtech/geowave/core/cli/operations/config/ConfigSection.java
+++ b/core/cli/src/main/java/org/locationtech/geowave/core/cli/operations/config/ConfigSection.java
@@ -10,10 +10,10 @@ package org.locationtech.geowave.core.cli.operations.config;
 
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.DefaultOperation;
-import org.locationtech.geowave.core.cli.operations.GeowaveTopLevelSection;
+import org.locationtech.geowave.core.cli.operations.GeoWaveTopLevelSection;
 import com.beust.jcommander.Parameters;
 
-@GeowaveOperation(name = "config", parentOperation = GeowaveTopLevelSection.class)
+@GeowaveOperation(name = "config", parentOperation = GeoWaveTopLevelSection.class)
 @Parameters(commandDescription = "Commands that affect local configuration only")
 public class ConfigSection extends DefaultOperation {
 }

--- a/core/cli/src/main/java/org/locationtech/geowave/core/cli/operations/config/ListCommand.java
+++ b/core/cli/src/main/java/org/locationtech/geowave/core/cli/operations/config/ListCommand.java
@@ -36,12 +36,12 @@ public class ListCommand extends ServiceEnabledCommand<SortedMap<String, Object>
     final Pair<String, SortedMap<String, Object>> list = getProperties(params);
     final String name = list.getKey();
 
-    JCommander.getConsole().println("PROPERTIES (" + name + ")");
+    params.getConsole().println("PROPERTIES (" + name + ")");
 
     final SortedMap<String, Object> properties = list.getValue();
 
     for (final Entry<String, Object> e : properties.entrySet()) {
-      JCommander.getConsole().println(e.getKey() + ": " + e.getValue());
+      params.getConsole().println(e.getKey() + ": " + e.getValue());
     }
   }
 

--- a/core/cli/src/main/java/org/locationtech/geowave/core/cli/operations/config/SetCommand.java
+++ b/core/cli/src/main/java/org/locationtech/geowave/core/cli/operations/config/SetCommand.java
@@ -99,7 +99,11 @@ public class SetCommand extends ServiceEnabledCommand<Object> {
         try {
           final File tokenFile =
               SecurityUtils.getFormattedTokenKeyFileForConfig(getGeoWaveConfigFile());
-          value = SecurityUtils.encryptAndHexEncodeValue(value, tokenFile.getAbsolutePath());
+          value =
+              SecurityUtils.encryptAndHexEncodeValue(
+                  value,
+                  tokenFile.getAbsolutePath(),
+                  params.getConsole());
           LOGGER.debug("Value was successfully encrypted");
         } catch (final Exception e) {
           LOGGER.error(
@@ -116,7 +120,7 @@ public class SetCommand extends ServiceEnabledCommand<Object> {
     }
 
     final Object previousValue = p.setProperty(key, value);
-    if (!ConfigOptions.writeProperties(f, p)) {
+    if (!ConfigOptions.writeProperties(f, p, params.getConsole())) {
       throw new WritePropertiesException("Write failure");
     } else {
       return previousValue;

--- a/core/cli/src/main/java/org/locationtech/geowave/core/cli/operations/config/security/NewTokenCommand.java
+++ b/core/cli/src/main/java/org/locationtech/geowave/core/cli/operations/config/security/NewTokenCommand.java
@@ -46,7 +46,7 @@ public class NewTokenCommand extends DefaultOperation implements Command {
                   + tokenFile.getCanonicalPath());
           sLog.info(
               "Creating new encryption token and migrating all passwords in [{}] to be encrypted with new token",
-              ConfigOptions.getDefaultPropertyFile().getCanonicalPath());
+              ConfigOptions.getDefaultPropertyFile(params.getConsole()).getCanonicalPath());
 
           File backupFile = null;
           boolean tokenBackedUp = false;
@@ -80,18 +80,23 @@ public class NewTokenCommand extends DefaultOperation implements Command {
                     final String decryptedValue =
                         SecurityUtils.decryptHexEncodedValue(
                             configValue,
-                            backupFile.getCanonicalPath());
+                            backupFile.getCanonicalPath(),
+                            params.getConsole());
                     final String encryptedValue =
                         SecurityUtils.encryptAndHexEncodeValue(
                             decryptedValue,
-                            tokenFile.getCanonicalPath());
+                            tokenFile.getCanonicalPath(),
+                            params.getConsole());
                     configProps.put(configKey, encryptedValue);
                     updated = true;
                   }
                 }
               }
               if (updated) {
-                ConfigOptions.writeProperties(getGeoWaveConfigFile(params), configProps);
+                ConfigOptions.writeProperties(
+                    getGeoWaveConfigFile(params),
+                    configProps,
+                    params.getConsole());
               }
             }
             // HP Fortify "NULL Pointer Dereference" false positive

--- a/core/cli/src/main/java/org/locationtech/geowave/core/cli/operations/config/security/crypto/BaseEncryption.java
+++ b/core/cli/src/main/java/org/locationtech/geowave/core/cli/operations/config/security/crypto/BaseEncryption.java
@@ -26,6 +26,7 @@ import org.locationtech.geowave.core.cli.operations.config.security.utils.Securi
 import org.locationtech.geowave.core.cli.utils.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.beust.jcommander.internal.Console;
 
 /**
  * Abstract base encryption class for setting up and defining common encryption/decryption methods
@@ -63,27 +64,27 @@ public abstract class BaseEncryption {
    *
    * @param resourceLocation Path to cryptography token key file
    */
-  public BaseEncryption(final String resourceLocation) {
+  public BaseEncryption(final String resourceLocation, Console console) {
     try {
       setResourceLocation(resourceLocation);
-      init();
+      init(console);
     } catch (final Throwable t) {
       LOGGER.error(t.getLocalizedMessage(), t);
     }
   }
 
   /** Base constructor for encryption */
-  public BaseEncryption() {
-    init();
+  public BaseEncryption(Console console) {
+    init(console);
   }
 
   /**
    * Method to initialize all required fields, check for the existence of the cryptography token
    * key, and generate the key for encryption/decryption
    */
-  private void init() {
+  private void init(Console console) {
     try {
-      checkForToken();
+      checkForToken(console);
       setResourceLocation(tokenFile.getCanonicalPath());
 
       salt = "Ge0W@v3-Ro0t-K3y".getBytes("UTF-8");
@@ -95,7 +96,7 @@ public abstract class BaseEncryption {
   }
 
   /** Check if encryption token exists. If not, create one initially */
-  private void checkForToken() throws Throwable {
+  private void checkForToken(Console console) throws Throwable {
     if (getResourceLocation() != null) {
       // this is simply caching the location, ideally under all
       // circumstances resource location exists
@@ -106,7 +107,8 @@ public abstract class BaseEncryption {
       // because of that assumption this can cause inconsistency
       // under all circumstances this seems like it should never happen
       tokenFile =
-          SecurityUtils.getFormattedTokenKeyFileForConfig(ConfigOptions.getDefaultPropertyFile());
+          SecurityUtils.getFormattedTokenKeyFileForConfig(
+              ConfigOptions.getDefaultPropertyFile(console));
     }
     if (!tokenFile.exists()) {
       generateNewEncryptionToken(tokenFile);

--- a/core/cli/src/main/java/org/locationtech/geowave/core/cli/operations/config/security/crypto/GeoWaveEncryption.java
+++ b/core/cli/src/main/java/org/locationtech/geowave/core/cli/operations/config/security/crypto/GeoWaveEncryption.java
@@ -20,6 +20,7 @@ import org.bouncycastle.crypto.params.KeyParameter;
 import org.bouncycastle.crypto.params.ParametersWithIV;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.beust.jcommander.internal.Console;
 
 /** Encryption/Decryption implementation based of symmetric cryptography */
 public class GeoWaveEncryption extends BaseEncryption {
@@ -31,13 +32,13 @@ public class GeoWaveEncryption extends BaseEncryption {
    *
    * @param resourceLocation Path to cryptography token key file
    */
-  public GeoWaveEncryption(final String resourceLocation) {
-    super(resourceLocation);
+  public GeoWaveEncryption(final String resourceLocation, Console console) {
+    super(resourceLocation, console);
   }
 
   /** Base constructor for encryption */
-  public GeoWaveEncryption() {
-    super();
+  public GeoWaveEncryption(Console console) {
+    super(console);
   }
 
   @Override

--- a/core/cli/src/main/java/org/locationtech/geowave/core/cli/operations/config/security/utils/SecurityUtils.java
+++ b/core/cli/src/main/java/org/locationtech/geowave/core/cli/operations/config/security/utils/SecurityUtils.java
@@ -14,6 +14,7 @@ import org.locationtech.geowave.core.cli.operations.config.security.crypto.BaseE
 import org.locationtech.geowave.core.cli.operations.config.security.crypto.GeoWaveEncryption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.beust.jcommander.internal.Console;
 
 /** Security utility class for simpler interfacing with */
 public class SecurityUtils {
@@ -30,13 +31,15 @@ public class SecurityUtils {
    *        resource location
    * @return decrypted value
    */
-  public static String decryptHexEncodedValue(final String value, final String resourceLocation)
-      throws Exception {
+  public static String decryptHexEncodedValue(
+      final String value,
+      final String resourceLocation,
+      Console console) throws Exception {
     LOGGER.trace("Decrypting hex-encoded value");
     if ((value != null) && !"".equals(value.trim())) {
       if (BaseEncryption.isProperlyWrapped(value.trim())) {
         try {
-          return getEncryptionService(resourceLocation).decryptHexEncoded(value);
+          return getEncryptionService(resourceLocation, console).decryptHexEncoded(value);
         } catch (final Throwable t) {
           LOGGER.error(
               "Encountered exception during content decryption: " + t.getLocalizedMessage(),
@@ -63,13 +66,15 @@ public class SecurityUtils {
    * @return If encryption is successful, encrypted and hex-encoded string value is returned wrapped
    *         with ENC{}
    */
-  public static String encryptAndHexEncodeValue(final String value, final String resourceLocation)
-      throws Exception {
+  public static String encryptAndHexEncodeValue(
+      final String value,
+      final String resourceLocation,
+      Console console) throws Exception {
     LOGGER.debug("Encrypting and hex-encoding value");
     if ((value != null) && !"".equals(value.trim())) {
       if (!BaseEncryption.isProperlyWrapped(value)) {
         try {
-          return getEncryptionService(resourceLocation).encryptAndHexEncode(value);
+          return getEncryptionService(resourceLocation, console).encryptAndHexEncode(value);
         } catch (final Throwable t) {
           LOGGER.error(
               "Encountered exception during content encryption: " + t.getLocalizedMessage(),
@@ -98,19 +103,20 @@ public class SecurityUtils {
    * @return An initialized instance of the encryption service
    * @throws Exception
    */
-  private static synchronized BaseEncryption getEncryptionService(final String resourceLocation)
-      throws Throwable {
+  private static synchronized BaseEncryption getEncryptionService(
+      final String resourceLocation,
+      Console console) throws Throwable {
     if (encService == null) {
       if ((resourceLocation != null) && !"".equals(resourceLocation.trim())) {
         LOGGER.trace(
             "Setting resource location for encryption service: [" + resourceLocation + "]");
-        encService = new GeoWaveEncryption(resourceLocation);
+        encService = new GeoWaveEncryption(resourceLocation, console);
       } else {
-        encService = new GeoWaveEncryption();
+        encService = new GeoWaveEncryption(console);
       }
     } else {
       if (!resourceLocation.equals(encService.getResourceLocation())) {
-        encService = new GeoWaveEncryption(resourceLocation);
+        encService = new GeoWaveEncryption(resourceLocation, console);
       }
     }
     return encService;

--- a/core/cli/src/main/java/org/locationtech/geowave/core/cli/operations/util/UtilSection.java
+++ b/core/cli/src/main/java/org/locationtech/geowave/core/cli/operations/util/UtilSection.java
@@ -10,10 +10,10 @@ package org.locationtech.geowave.core.cli.operations.util;
 
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.DefaultOperation;
-import org.locationtech.geowave.core.cli.operations.GeowaveTopLevelSection;
+import org.locationtech.geowave.core.cli.operations.GeoWaveTopLevelSection;
 import com.beust.jcommander.Parameters;
 
-@GeowaveOperation(name = {"util", "utility"}, parentOperation = GeowaveTopLevelSection.class)
+@GeowaveOperation(name = {"util", "utility"}, parentOperation = GeoWaveTopLevelSection.class)
 @Parameters(commandDescription = "GeoWave utility commands")
 public class UtilSection extends DefaultOperation {
 }

--- a/core/cli/src/main/java/org/locationtech/geowave/core/cli/parser/CommandLineOperationParams.java
+++ b/core/cli/src/main/java/org/locationtech/geowave/core/cli/parser/CommandLineOperationParams.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import org.locationtech.geowave.core.cli.api.Operation;
 import org.locationtech.geowave.core.cli.api.OperationParams;
 import org.locationtech.geowave.core.cli.prefix.PrefixedJCommander;
+import com.beust.jcommander.internal.Console;
 
 public class CommandLineOperationParams implements OperationParams {
   private final Map<String, Object> context = new HashMap<>();
@@ -48,6 +49,10 @@ public class CommandLineOperationParams implements OperationParams {
 
   public PrefixedJCommander getCommander() {
     return commander;
+  }
+
+  public Console getConsole() {
+    return commander.getConsole();
   }
 
   public void setValidate(final boolean validate) {

--- a/core/cli/src/main/java/org/locationtech/geowave/core/cli/parser/ManualOperationParams.java
+++ b/core/cli/src/main/java/org/locationtech/geowave/core/cli/parser/ManualOperationParams.java
@@ -12,6 +12,8 @@ import java.util.HashMap;
 import java.util.Map;
 import org.locationtech.geowave.core.cli.api.Operation;
 import org.locationtech.geowave.core.cli.api.OperationParams;
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.internal.Console;
 
 public class ManualOperationParams implements OperationParams {
 
@@ -25,5 +27,10 @@ public class ManualOperationParams implements OperationParams {
   @Override
   public Map<String, Object> getContext() {
     return context;
+  }
+
+  @Override
+  public Console getConsole() {
+    return new JCommander().getConsole();
   }
 }

--- a/core/cli/src/main/java/org/locationtech/geowave/core/cli/prefix/JCommanderPrefixTranslator.java
+++ b/core/cli/src/main/java/org/locationtech/geowave/core/cli/prefix/JCommanderPrefixTranslator.java
@@ -43,21 +43,21 @@ public class JCommanderPrefixTranslator {
       // HP Fortify "Access Specifier Manipulation"
       // These fields are being modified by trusted code,
       // in a way that is not influenced by user input
-      paraField = Parameterized.class.getDeclaredField("m_field");
+      paraField = Parameterized.class.getDeclaredField("field");
       paraField.setAccessible(true);
 
-      paraMethod = Parameterized.class.getDeclaredField("m_method");
+      paraMethod = Parameterized.class.getDeclaredField("method");
       paraMethod.setAccessible(true);
     } catch (final NoSuchFieldException e) {
       // This is a programmer error, and will only happen if another
       // version of JCommander is being used.
-      // newer versions of JCommander have renamed the member variables, try the new names
+      // newer versions of JCommander have renamed the member variables, try the old names
       try {
-        paraField = Parameterized.class.getDeclaredField("field");
+        paraField = Parameterized.class.getDeclaredField("m_field");
 
         paraField.setAccessible(true);
 
-        paraMethod = Parameterized.class.getDeclaredField("method");
+        paraMethod = Parameterized.class.getDeclaredField("m_method");
         paraMethod.setAccessible(true);
       } catch (NoSuchFieldException e2) {
         throw new RuntimeException(e);

--- a/core/cli/src/main/java/org/locationtech/geowave/core/cli/prefix/JCommanderPropertiesTransformer.java
+++ b/core/cli/src/main/java/org/locationtech/geowave/core/cli/prefix/JCommanderPropertiesTransformer.java
@@ -175,7 +175,7 @@ public class JCommanderPropertiesTransformer {
           // set it on the original object.
           entry.getParam().set(
               entry.getObject(),
-              jc.convertValue(entry.getParam(), entry.getParam().getType(), value));
+              jc.convertValue(entry.getParam(), entry.getParam().getType(), propertyName, value));
         }
       }
     }

--- a/core/cli/src/test/java/org/locationtech/geowave/core/cli/VersionUtilsTest.java
+++ b/core/cli/src/test/java/org/locationtech/geowave/core/cli/VersionUtilsTest.java
@@ -10,6 +10,7 @@ package org.locationtech.geowave.core.cli;
 
 import static org.junit.Assert.assertEquals;
 import org.junit.Test;
+import com.beust.jcommander.JCommander;
 
 public class VersionUtilsTest {
 
@@ -19,6 +20,6 @@ public class VersionUtilsTest {
     // version
     assertEquals(
         version, // change this value when it gives a version
-        VersionUtils.getVersion());
+        VersionUtils.getVersion(new JCommander().getConsole()));
   }
 }

--- a/core/cli/src/test/java/org/locationtech/geowave/core/cli/operations/ExplainCommandTest.java
+++ b/core/cli/src/test/java/org/locationtech/geowave/core/cli/operations/ExplainCommandTest.java
@@ -21,7 +21,7 @@ public class ExplainCommandTest {
     final String[] args = {"explain"};
     final OperationRegistry registry = OperationRegistry.getInstance();
     final OperationParser parser = new OperationParser(registry);
-    final CommandLineOperationParams params = parser.parse(GeowaveTopLevelSection.class, args);
+    final CommandLineOperationParams params = parser.parse(GeoWaveTopLevelSection.class, args);
 
     final ExplainCommand expcommand = new ExplainCommand();
     expcommand.prepare(params);

--- a/core/cli/src/test/java/org/locationtech/geowave/core/cli/operations/HelpCommandTest.java
+++ b/core/cli/src/test/java/org/locationtech/geowave/core/cli/operations/HelpCommandTest.java
@@ -20,7 +20,7 @@ public class HelpCommandTest {
     final String[] args = {"help"};
     final OperationRegistry registry = OperationRegistry.getInstance();
     final OperationParser parser = new OperationParser(registry);
-    final CommandLineOperationParams params = parser.parse(GeowaveTopLevelSection.class, args);
+    final CommandLineOperationParams params = parser.parse(GeoWaveTopLevelSection.class, args);
 
     final HelpCommand helpcommand = new HelpCommand();
     helpcommand.prepare(params);

--- a/core/cli/src/test/java/org/locationtech/geowave/core/cli/operations/config/SetCommandTest.java
+++ b/core/cli/src/test/java/org/locationtech/geowave/core/cli/operations/config/SetCommandTest.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.assertEquals;
 import java.io.File;
 import java.util.Properties;
 import org.junit.Test;
-import org.locationtech.geowave.core.cli.operations.GeowaveTopLevelSection;
+import org.locationtech.geowave.core.cli.operations.GeoWaveTopLevelSection;
 import org.locationtech.geowave.core.cli.operations.config.options.ConfigOptions;
 import org.locationtech.geowave.core.cli.parser.CommandLineOperationParams;
 import org.locationtech.geowave.core.cli.parser.OperationParser;
@@ -25,7 +25,7 @@ public class SetCommandTest {
     final String[] args = {"config", "set", "name", "value"};
     final OperationRegistry registry = OperationRegistry.getInstance();
     final OperationParser parser = new OperationParser(registry);
-    final CommandLineOperationParams params = parser.parse(GeowaveTopLevelSection.class, args);
+    final CommandLineOperationParams params = parser.parse(GeoWaveTopLevelSection.class, args);
 
     final SetCommand setcommand = new SetCommand();
     final String name = "name";

--- a/core/cli/src/test/java/org/locationtech/geowave/core/cli/operations/config/options/ConfigOptionsTest.java
+++ b/core/cli/src/test/java/org/locationtech/geowave/core/cli/operations/config/options/ConfigOptionsTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertEquals;
 import java.io.File;
 import java.util.Properties;
 import org.junit.Test;
+import com.beust.jcommander.JCommander;
 
 public class ConfigOptionsTest {
   @Test
@@ -23,7 +24,8 @@ public class ConfigOptionsTest {
     final String key = "key";
     final String value = "value";
     prop.setProperty(key, value);
-    final boolean success = ConfigOptions.writeProperties(configfile, prop);
+    final boolean success =
+        ConfigOptions.writeProperties(configfile, prop, new JCommander().getConsole());
     if (success) {
       final Properties loadprop = ConfigOptions.loadProperties(configfile);
       assertEquals(value, loadprop.getProperty(key));

--- a/core/cli/src/test/java/org/locationtech/geowave/core/cli/operations/config/security/SecurityUtilsTest.java
+++ b/core/cli/src/test/java/org/locationtech/geowave/core/cli/operations/config/security/SecurityUtilsTest.java
@@ -14,21 +14,27 @@ import java.io.File;
 import org.junit.Test;
 import org.locationtech.geowave.core.cli.operations.config.options.ConfigOptions;
 import org.locationtech.geowave.core.cli.operations.config.security.utils.SecurityUtils;
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.internal.Console;
 
 /** Unit test cases for encrypting and decrypting values */
 public class SecurityUtilsTest {
   @Test
   public void testEncryptionDecryption() throws Exception {
     final String rawInput = "geowave";
-
+    Console console = new JCommander().getConsole();
     final File tokenFile =
-        SecurityUtils.getFormattedTokenKeyFileForConfig(ConfigOptions.getDefaultPropertyFile());
+        SecurityUtils.getFormattedTokenKeyFileForConfig(
+            ConfigOptions.getDefaultPropertyFile(console));
     if ((tokenFile != null) && tokenFile.exists()) {
       final String encryptedValue =
-          SecurityUtils.encryptAndHexEncodeValue(rawInput, tokenFile.getCanonicalPath());
+          SecurityUtils.encryptAndHexEncodeValue(rawInput, tokenFile.getCanonicalPath(), console);
 
       final String decryptedValue =
-          SecurityUtils.decryptHexEncodedValue(encryptedValue, tokenFile.getCanonicalPath());
+          SecurityUtils.decryptHexEncodedValue(
+              encryptedValue,
+              tokenFile.getCanonicalPath(),
+              console);
 
       assertEquals(decryptedValue, rawInput);
     }

--- a/core/ingest/src/main/java/org/locationtech/geowave/core/ingest/operations/ConfigAWSCommand.java
+++ b/core/ingest/src/main/java/org/locationtech/geowave/core/ingest/operations/ConfigAWSCommand.java
@@ -62,7 +62,8 @@ public class ConfigAWSCommand extends DefaultOperation implements Command {
         getGeoWaveConfigFile(params),
         existingProps,
         this.getClass(),
-        AWS_S3_ENDPOINT_PREFIX);
+        AWS_S3_ENDPOINT_PREFIX,
+        params.getConsole());
   }
 
   public static String getS3Url(final Properties configProperties) {

--- a/core/ingest/src/main/java/org/locationtech/geowave/core/ingest/operations/IngestOperationProvider.java
+++ b/core/ingest/src/main/java/org/locationtech/geowave/core/ingest/operations/IngestOperationProvider.java
@@ -15,15 +15,15 @@ public class IngestOperationProvider implements CLIOperationProviderSpi {
   private static final Class<?>[] OPERATIONS =
       new Class<?>[] {
           IngestSection.class,
-          KafkaToGeowaveCommand.class,
+          KafkaToGeoWaveCommand.class,
           ListIngestPluginsCommand.class,
-          LocalToGeowaveCommand.class,
+          LocalToGeoWaveCommand.class,
           LocalToHdfsCommand.class,
           LocalToKafkaCommand.class,
-          LocalToMapReduceToGeowaveCommand.class,
-          MapReduceToGeowaveCommand.class,
+          LocalToMapReduceToGeoWaveCommand.class,
+          MapReduceToGeoWaveCommand.class,
           ConfigAWSCommand.class,
-          SparkToGeowaveCommand.class};
+          SparkToGeoWaveCommand.class};
 
   @Override
   public Class<?>[] getOperations() {

--- a/core/ingest/src/main/java/org/locationtech/geowave/core/ingest/operations/IngestSection.java
+++ b/core/ingest/src/main/java/org/locationtech/geowave/core/ingest/operations/IngestSection.java
@@ -10,10 +10,10 @@ package org.locationtech.geowave.core.ingest.operations;
 
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.DefaultOperation;
-import org.locationtech.geowave.core.cli.operations.GeowaveTopLevelSection;
+import org.locationtech.geowave.core.cli.operations.GeoWaveTopLevelSection;
 import com.beust.jcommander.Parameters;
 
-@GeowaveOperation(name = "ingest", parentOperation = GeowaveTopLevelSection.class)
+@GeowaveOperation(name = "ingest", parentOperation = GeoWaveTopLevelSection.class)
 @Parameters(
     commandDescription = "Commands that ingest data directly into GeoWave or stage data to be ingested into GeoWave")
 public class IngestSection extends DefaultOperation {

--- a/core/ingest/src/main/java/org/locationtech/geowave/core/ingest/operations/ListIngestPluginsCommand.java
+++ b/core/ingest/src/main/java/org/locationtech/geowave/core/ingest/operations/ListIngestPluginsCommand.java
@@ -14,7 +14,6 @@ import org.locationtech.geowave.core.cli.api.OperationParams;
 import org.locationtech.geowave.core.cli.api.ServiceEnabledCommand;
 import org.locationtech.geowave.core.ingest.spi.IngestFormatPluginProviderSpi;
 import org.locationtech.geowave.core.ingest.spi.IngestFormatPluginRegistry;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameters;
 
 @GeowaveOperation(name = "listplugins", parentOperation = IngestSection.class)
@@ -23,7 +22,7 @@ public class ListIngestPluginsCommand extends ServiceEnabledCommand<String> {
 
   @Override
   public void execute(final OperationParams params) {
-    JCommander.getConsole().println(computeResults(params));
+    params.getConsole().println(computeResults(params));
   }
 
   @Override

--- a/core/ingest/src/main/java/org/locationtech/geowave/core/ingest/operations/LocalToGeoWaveCommand.java
+++ b/core/ingest/src/main/java/org/locationtech/geowave/core/ingest/operations/LocalToGeoWaveCommand.java
@@ -15,15 +15,14 @@ import java.util.Map;
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.OperationParams;
 import org.locationtech.geowave.core.cli.api.ServiceEnabledCommand;
-import org.locationtech.geowave.core.ingest.avro.GeoWaveAvroFormatPlugin;
-import org.locationtech.geowave.core.ingest.kafka.IngestFromKafkaDriver;
-import org.locationtech.geowave.core.ingest.kafka.KafkaConsumerCommandLineOptions;
+import org.locationtech.geowave.core.ingest.local.LocalFileIngestCLIDriver;
 import org.locationtech.geowave.core.ingest.operations.options.IngestFormatPluginOptions;
 import org.locationtech.geowave.core.store.api.Index;
 import org.locationtech.geowave.core.store.cli.VisibilityOptions;
 import org.locationtech.geowave.core.store.cli.store.DataStorePluginOptions;
 import org.locationtech.geowave.core.store.cli.store.StoreLoader;
 import org.locationtech.geowave.core.store.index.IndexStore;
+import org.locationtech.geowave.core.store.ingest.LocalFileIngestPlugin;
 import org.locationtech.geowave.core.store.ingest.LocalInputCommandLineOptions;
 import org.locationtech.geowave.core.store.util.DataStoreUtils;
 import com.beust.jcommander.Parameter;
@@ -31,18 +30,16 @@ import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.ParametersDelegate;
 
-@GeowaveOperation(name = "kafkaToGW", parentOperation = IngestSection.class)
-@Parameters(commandDescription = "Subscribe to a Kafka topic and ingest into GeoWave")
-public class KafkaToGeowaveCommand extends ServiceEnabledCommand<Void> {
+@GeowaveOperation(name = "localToGW", parentOperation = IngestSection.class)
+@Parameters(
+    commandDescription = "Ingest supported files in local file system directly, from S3 or from HDFS")
+public class LocalToGeoWaveCommand extends ServiceEnabledCommand<Void> {
 
-  @Parameter(description = "<store name> <comma delimited index list>")
+  @Parameter(description = "<file or directory> <store name> <comma delimited index list>")
   private List<String> parameters = new ArrayList<>();
 
   @ParametersDelegate
   private VisibilityOptions ingestOptions = new VisibilityOptions();
-
-  @ParametersDelegate
-  private KafkaConsumerCommandLineOptions kafkaOptions = new KafkaConsumerCommandLineOptions();
 
   @ParametersDelegate
   private LocalInputCommandLineOptions localInputOptions = new LocalInputCommandLineOptions();
@@ -52,17 +49,17 @@ public class KafkaToGeowaveCommand extends ServiceEnabledCommand<Void> {
   @ParametersDelegate
   private IngestFormatPluginOptions pluginFormats = new IngestFormatPluginOptions();
 
+  @Parameter(
+      names = {"-t", "--threads"},
+      description = "number of threads to use for ingest, default to 1 (optional)")
+  private int threads = 1;
+
   private DataStorePluginOptions inputStoreOptions = null;
 
   private List<Index> inputIndices = null;
 
-  protected IngestFromKafkaDriver driver = null;
-
   @Override
   public boolean prepare(final OperationParams params) {
-
-    // TODO: localInputOptions has 'extensions' which doesn't mean
-    // anything for Kafka to Geowave
 
     // Based on the selected formats, select the format plugins
     pluginFormats.selectPlugin(localInputOptions.getFormats());
@@ -70,19 +67,9 @@ public class KafkaToGeowaveCommand extends ServiceEnabledCommand<Void> {
     return true;
   }
 
-  /**
-   * Prep the driver & run the operation.
-   *
-   * @throws Exception
-   */
+  /** Prep the driver & run the operation. */
   @Override
-  public void execute(final OperationParams params) throws Exception {
-
-    // Ensure we have all the required arguments
-    if (parameters.size() != 2) {
-      throw new ParameterException("Requires arguments: <store name> <comma delimited index list>");
-    }
-
+  public void execute(final OperationParams params) {
     computeResults(params);
   }
 
@@ -91,18 +78,18 @@ public class KafkaToGeowaveCommand extends ServiceEnabledCommand<Void> {
     return true;
   }
 
-  public IngestFromKafkaDriver getDriver() {
-    return driver;
-  }
-
   public List<String> getParameters() {
     return parameters;
   }
 
-  public void setParameters(final String storeName, final String commaSeparatedIndexes) {
+  public void setParameters(
+      final String fileOrDirectory,
+      final String storeName,
+      final String commaDelimitedIndexes) {
     parameters = new ArrayList<>();
+    parameters.add(fileOrDirectory);
     parameters.add(storeName);
-    parameters.add(commaSeparatedIndexes);
+    parameters.add(commaDelimitedIndexes);
   }
 
   public VisibilityOptions getIngestOptions() {
@@ -111,14 +98,6 @@ public class KafkaToGeowaveCommand extends ServiceEnabledCommand<Void> {
 
   public void setIngestOptions(final VisibilityOptions ingestOptions) {
     this.ingestOptions = ingestOptions;
-  }
-
-  public KafkaConsumerCommandLineOptions getKafkaOptions() {
-    return kafkaOptions;
-  }
-
-  public void setKafkaOptions(final KafkaConsumerCommandLineOptions kafkaOptions) {
-    this.kafkaOptions = kafkaOptions;
   }
 
   public LocalInputCommandLineOptions getLocalInputOptions() {
@@ -137,6 +116,14 @@ public class KafkaToGeowaveCommand extends ServiceEnabledCommand<Void> {
     this.pluginFormats = pluginFormats;
   }
 
+  public int getThreads() {
+    return threads;
+  }
+
+  public void setThreads(final int threads) {
+    this.threads = threads;
+  }
+
   public DataStorePluginOptions getInputStoreOptions() {
     return inputStoreOptions;
   }
@@ -146,37 +133,46 @@ public class KafkaToGeowaveCommand extends ServiceEnabledCommand<Void> {
   }
 
   @Override
-  public Void computeResults(final OperationParams params) throws Exception {
-    final String inputStoreName = parameters.get(0);
-    final String indexList = parameters.get(1);
+  public Void computeResults(final OperationParams params) {
+    // Ensure we have all the required arguments
+    if (parameters.size() != 3) {
+      throw new ParameterException(
+          "Requires arguments: <file or directory> <storename> <comma delimited index list>");
+    }
+
+    final String inputPath = parameters.get(0);
+    final String inputStoreName = parameters.get(1);
+    final String indexList = parameters.get(2);
 
     // Config file
     final File configFile = getGeoWaveConfigFile(params);
 
     final StoreLoader inputStoreLoader = new StoreLoader(inputStoreName);
-    if (!inputStoreLoader.loadFromConfig(configFile)) {
+    if (!inputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
     }
     inputStoreOptions = inputStoreLoader.getDataStorePlugin();
 
     final IndexStore indexStore = inputStoreOptions.createIndexStore();
+
     inputIndices = DataStoreUtils.loadIndices(indexStore, indexList);
 
     // Ingest Plugins
-    final Map<String, GeoWaveAvroFormatPlugin<?, ?>> ingestPlugins =
-        pluginFormats.createAvroPlugins();
+    final Map<String, LocalFileIngestPlugin<?>> ingestPlugins =
+        pluginFormats.createLocalIngestPlugins();
 
     // Driver
-    driver =
-        new IngestFromKafkaDriver(
+    final LocalFileIngestCLIDriver driver =
+        new LocalFileIngestCLIDriver(
             inputStoreOptions,
             inputIndices,
             ingestPlugins,
-            kafkaOptions,
-            ingestOptions);
+            ingestOptions,
+            localInputOptions,
+            threads);
 
     // Execute
-    if (!driver.runOperation()) {
+    if (!driver.runOperation(inputPath, configFile)) {
       throw new RuntimeException("Ingest failed to execute");
     }
     return null;

--- a/core/ingest/src/main/java/org/locationtech/geowave/core/ingest/operations/LocalToMapReduceToGeoWaveCommand.java
+++ b/core/ingest/src/main/java/org/locationtech/geowave/core/ingest/operations/LocalToMapReduceToGeoWaveCommand.java
@@ -39,7 +39,7 @@ import com.beust.jcommander.ParametersDelegate;
 @GeowaveOperation(name = "localToMrGW", parentOperation = IngestSection.class)
 @Parameters(
     commandDescription = "Copy supported files from local file system to HDFS and ingest from HDFS")
-public class LocalToMapReduceToGeowaveCommand extends ServiceEnabledCommand<Void> {
+public class LocalToMapReduceToGeoWaveCommand extends ServiceEnabledCommand<Void> {
 
   @Parameter(
       description = "<file or directory> <path to base directory to write to> <store name> <comma delimited index list>")
@@ -168,7 +168,7 @@ public class LocalToMapReduceToGeowaveCommand extends ServiceEnabledCommand<Void
     final String hdfsHostPort = ConfigHDFSCommand.getHdfsUrl(configProperties);
 
     final StoreLoader inputStoreLoader = new StoreLoader(inputStoreName);
-    if (!inputStoreLoader.loadFromConfig(configFile)) {
+    if (!inputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
     }
     inputStoreOptions = inputStoreLoader.getDataStorePlugin();

--- a/core/ingest/src/main/java/org/locationtech/geowave/core/ingest/operations/SparkToGeoWaveCommand.java
+++ b/core/ingest/src/main/java/org/locationtech/geowave/core/ingest/operations/SparkToGeoWaveCommand.java
@@ -25,7 +25,7 @@ import com.beust.jcommander.ParametersDelegate;
 
 @GeowaveOperation(name = "sparkToGW", parentOperation = IngestSection.class)
 @Parameters(commandDescription = "Ingest supported files that already exist in HDFS or S3")
-public class SparkToGeowaveCommand extends ServiceEnabledCommand<Void> {
+public class SparkToGeoWaveCommand extends ServiceEnabledCommand<Void> {
 
   @Parameter(description = "<input directory> <store name> <comma delimited index list>")
   private List<String> parameters = new ArrayList<>();
@@ -126,7 +126,8 @@ public class SparkToGeowaveCommand extends ServiceEnabledCommand<Void> {
         indexList,
         ingestOptions,
         sparkOptions,
-        inputPath)) {
+        inputPath,
+        params.getConsole())) {
       throw new RuntimeException("Ingest failed to execute");
     }
 

--- a/core/ingest/src/main/java/org/locationtech/geowave/core/ingest/spark/SparkIngestDriver.java
+++ b/core/ingest/src/main/java/org/locationtech/geowave/core/ingest/spark/SparkIngestDriver.java
@@ -59,7 +59,9 @@ import org.locationtech.geowave.mapreduce.operations.ConfigHDFSCommand;
 import org.locationtech.geowave.mapreduce.s3.GeoWaveAmazonS3Factory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
+import com.beust.jcommander.internal.Console;
 import com.google.common.collect.Lists;
 import com.upplication.s3fs.S3FileSystem;
 import com.upplication.s3fs.S3FileSystemProvider;
@@ -81,7 +83,8 @@ public class SparkIngestDriver implements Serializable {
       final String indexList,
       final VisibilityOptions ingestOptions,
       final SparkCommandLineOptions sparkOptions,
-      final String basePath) throws IOException {
+      final String basePath,
+      final Console console) throws IOException {
 
     final Properties configProperties = ConfigOptions.loadProperties(configFile);
 
@@ -184,7 +187,8 @@ public class SparkIngestDriver implements Serializable {
             indexList,
             ingestOptions,
             configProperties,
-            inputFiles.iterator());
+            inputFiles.iterator(),
+            console);
       });
     } else if (isHDFS) {
       try {
@@ -202,7 +206,8 @@ public class SparkIngestDriver implements Serializable {
             indexList,
             ingestOptions,
             configProperties,
-            uri);
+            uri,
+            new JCommander().getConsole());
       });
     }
 
@@ -217,7 +222,8 @@ public class SparkIngestDriver implements Serializable {
       final String indexList,
       final VisibilityOptions ingestOptions,
       final Properties configProperties,
-      final Iterator<URI> inputFiles) throws IOException {
+      final Iterator<URI> inputFiles,
+      final Console console) throws IOException {
 
     // Based on the selected formats, select the format plugins
     final IngestFormatPluginOptions pluginFormats = new IngestFormatPluginOptions();
@@ -234,7 +240,8 @@ public class SparkIngestDriver implements Serializable {
     if (!inputStoreLoader.loadFromConfig(
         configProperties,
         DataStorePluginOptions.getStoreNamespace(inputStoreName),
-        configFile)) {
+        configFile,
+        console)) {
       throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
     }
     inputStoreOptions = inputStoreLoader.getDataStorePlugin();

--- a/core/mapreduce/src/main/java/org/locationtech/geowave/mapreduce/dedupe/GeoWaveDedupeJobRunner.java
+++ b/core/mapreduce/src/main/java/org/locationtech/geowave/mapreduce/dedupe/GeoWaveDedupeJobRunner.java
@@ -111,7 +111,9 @@ public class GeoWaveDedupeJobRunner extends AbstractGeoWaveJobRunner {
     opts.prepare(params);
 
     final StoreLoader loader = new StoreLoader(holder.getMainParameter().get(0));
-    loader.loadFromConfig((File) params.getContext().get(ConfigOptions.PROPERTIES_FILE_CONTEXT));
+    loader.loadFromConfig(
+        (File) params.getContext().get(ConfigOptions.PROPERTIES_FILE_CONTEXT),
+        params.getConsole());
 
     final int res =
         ToolRunner.run(

--- a/core/mapreduce/src/main/java/org/locationtech/geowave/mapreduce/operations/ConfigHDFSCommand.java
+++ b/core/mapreduce/src/main/java/org/locationtech/geowave/mapreduce/operations/ConfigHDFSCommand.java
@@ -88,7 +88,8 @@ public class ConfigHDFSCommand extends ServiceEnabledCommand<Void> {
         getGeoWaveConfigFile(params),
         existingProps,
         this.getClass(),
-        HDFS_DEFAULTFS_PREFIX);
+        HDFS_DEFAULTFS_PREFIX,
+        params.getConsole());
 
     return null;
   }

--- a/core/mapreduce/src/main/java/org/locationtech/geowave/mapreduce/operations/CopyCommand.java
+++ b/core/mapreduce/src/main/java/org/locationtech/geowave/mapreduce/operations/CopyCommand.java
@@ -62,14 +62,14 @@ public class CopyCommand extends DefaultOperation implements Command {
     }
 
     final StoreLoader inputStoreLoader = new StoreLoader(inputStoreName);
-    if (!inputStoreLoader.loadFromConfig(configFile)) {
+    if (!inputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
     }
     inputStoreOptions = inputStoreLoader.getDataStorePlugin();
 
     // Attempt to load output store.
     final StoreLoader outputStoreLoader = new StoreLoader(outputStoreName);
-    if (!outputStoreLoader.loadFromConfig(configFile)) {
+    if (!outputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + outputStoreLoader.getStoreName());
     }
     outputStoreOptions = outputStoreLoader.getDataStorePlugin();

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/StoreFactoryOptions.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/StoreFactoryOptions.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
+import com.beust.jcommander.internal.Console;
 
 /** This interface doesn't actually do anything, is just used for tracking during development. */
 public abstract class StoreFactoryOptions {
@@ -58,8 +59,8 @@ public abstract class StoreFactoryOptions {
 
   public abstract DataStoreOptions getStoreOptions();
 
-  public void validatePluginOptions() throws ParameterException {
-    validatePluginOptions(new Properties());
+  public void validatePluginOptions(final Console console) throws ParameterException {
+    validatePluginOptions(new Properties(), console);
   }
 
   /**
@@ -67,7 +68,8 @@ public abstract class StoreFactoryOptions {
    *
    * @throws Exception
    */
-  public void validatePluginOptions(final Properties properties) throws ParameterException {
+  public void validatePluginOptions(final Properties properties, final Console console)
+      throws ParameterException {
     LOGGER.trace("ENTER :: validatePluginOptions()");
     final PropertiesUtils propsUtils = new PropertiesUtils(properties);
     final boolean defaultEchoEnabled =
@@ -95,18 +97,18 @@ public abstract class StoreFactoryOptions {
             try {
               value = field.get(this);
               if (value == null) {
-                JCommander.getConsole().println(
+                console.println(
                     "Field ["
                         + field.getName()
                         + "] is required: "
                         + Arrays.toString(parameter.names())
                         + ": "
                         + parameter.description());
-                JCommander.getConsole().print("Enter value for [" + field.getName() + "]: ");
+                console.print("Enter value for [" + field.getName() + "]: ");
                 final boolean echoEnabled =
                     JCommanderParameterUtils.isPassword(parameter) ? passwordEchoEnabled
                         : defaultEchoEnabled;
-                char[] password = JCommander.getConsole().readPassword(echoEnabled);
+                char[] password = console.readPassword(echoEnabled);
                 final String strPassword = new String(password);
                 password = null;
 

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/cli/index/AddIndexCommand.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/cli/index/AddIndexCommand.java
@@ -61,6 +61,10 @@ public class AddIndexCommand extends ServiceEnabledCommand<String> {
     return true;
   }
 
+  public void setBasicIndexOptions(BasicIndexOptions basicIndexOptions) {
+    this.basicIndexOptions = basicIndexOptions;
+  }
+
   @Override
   public void execute(final OperationParams params) {
     // Ensure we have all the required arguments
@@ -82,7 +86,7 @@ public class AddIndexCommand extends ServiceEnabledCommand<String> {
     final File configFile = getGeoWaveConfigFile(params);
 
     final StoreLoader inputStoreLoader = new StoreLoader(storeName);
-    if (!inputStoreLoader.loadFromConfig(configFile)) {
+    if (!inputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
     }
     final DataStorePluginOptions storeOptions = inputStoreLoader.getDataStorePlugin();

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/cli/index/CompactIndexCommand.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/cli/index/CompactIndexCommand.java
@@ -23,7 +23,6 @@ import org.locationtech.geowave.core.store.cli.store.DataStorePluginOptions;
 import org.locationtech.geowave.core.store.cli.store.StoreLoader;
 import org.locationtech.geowave.core.store.operations.DataStoreOperations;
 import org.locationtech.geowave.core.store.util.DataStoreUtils;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
@@ -51,7 +50,7 @@ public class CompactIndexCommand extends DefaultOperation implements Command {
     final String indexList = parameters.get(1);
 
     final StoreLoader inputStoreLoader = new StoreLoader(inputStoreName);
-    if (!inputStoreLoader.loadFromConfig(getGeoWaveConfigFile(params))) {
+    if (!inputStoreLoader.loadFromConfig(getGeoWaveConfigFile(params), params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
     }
     inputStoreOptions = inputStoreLoader.getDataStorePlugin();
@@ -73,10 +72,9 @@ public class CompactIndexCommand extends DefaultOperation implements Command {
           internalAdapterStore,
           adapterIndexMappingStore,
           inputStoreOptions.getFactoryOptions().getStoreOptions().getMaxRangeDecomposition())) {
-        JCommander.getConsole().println(
-            "Unable to merge data within index '" + index.getName() + "'");
+        params.getConsole().println("Unable to merge data within index '" + index.getName() + "'");
       } else {
-        JCommander.getConsole().println(
+        params.getConsole().println(
             "Data successfully merged within index '" + index.getName() + "'");
       }
     }

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/cli/index/IndexSection.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/cli/index/IndexSection.java
@@ -10,10 +10,10 @@ package org.locationtech.geowave.core.store.cli.index;
 
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.DefaultOperation;
-import org.locationtech.geowave.core.cli.operations.GeowaveTopLevelSection;
+import org.locationtech.geowave.core.cli.operations.GeoWaveTopLevelSection;
 import com.beust.jcommander.Parameters;
 
-@GeowaveOperation(name = "index", parentOperation = GeowaveTopLevelSection.class)
+@GeowaveOperation(name = "index", parentOperation = GeoWaveTopLevelSection.class)
 @Parameters(commandDescription = "Commands to manage indices")
 public class IndexSection extends DefaultOperation {
 }

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/cli/index/ListIndexPluginsCommand.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/cli/index/ListIndexPluginsCommand.java
@@ -14,7 +14,6 @@ import org.locationtech.geowave.core.cli.api.OperationParams;
 import org.locationtech.geowave.core.cli.api.ServiceEnabledCommand;
 import org.locationtech.geowave.core.store.spi.DimensionalityTypeProviderSpi;
 import org.locationtech.geowave.core.store.spi.DimensionalityTypeRegistry;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameters;
 
 @GeowaveOperation(name = "listplugins", parentOperation = IndexSection.class)
@@ -23,7 +22,7 @@ public class ListIndexPluginsCommand extends ServiceEnabledCommand<String> {
 
   @Override
   public void execute(final OperationParams params) {
-    JCommander.getConsole().println(computeResults(params));
+    params.getConsole().println(computeResults(params));
   }
 
   @Override

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/cli/index/ListIndicesCommand.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/cli/index/ListIndicesCommand.java
@@ -19,7 +19,6 @@ import org.locationtech.geowave.core.store.CloseableIterator;
 import org.locationtech.geowave.core.store.api.Index;
 import org.locationtech.geowave.core.store.cli.store.DataStorePluginOptions;
 import org.locationtech.geowave.core.store.cli.store.StoreLoader;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
@@ -32,7 +31,11 @@ public class ListIndicesCommand extends ServiceEnabledCommand<String> {
 
   @Override
   public void execute(final OperationParams params) throws TargetNotFoundException {
-    JCommander.getConsole().println(computeResults(params));
+    params.getConsole().println(computeResults(params));
+  }
+
+  public void setParameters(List<String> parameters) {
+    this.parameters = parameters;
   }
 
   @Override
@@ -52,7 +55,7 @@ public class ListIndicesCommand extends ServiceEnabledCommand<String> {
     String result;
 
     final StoreLoader inputStoreLoader = new StoreLoader(inputStoreName);
-    if (!inputStoreLoader.loadFromConfig(configFile)) {
+    if (!inputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
     } else {
 

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/cli/index/RemoveIndexCommand.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/cli/index/RemoveIndexCommand.java
@@ -40,8 +40,12 @@ public class RemoveIndexCommand extends ServiceEnabledCommand<String> {
     computeResults(params);
   }
 
+  public void setParameters(final List<String> parameters) {
+    this.parameters = parameters;
+  }
+
   @Override
-  public String computeResults(OperationParams params) throws Exception {
+  public String computeResults(final OperationParams params) throws Exception {
     final String storeName = parameters.get(0);
     final String indexName = parameters.get(1);
 
@@ -49,14 +53,14 @@ public class RemoveIndexCommand extends ServiceEnabledCommand<String> {
     final File configFile = getGeoWaveConfigFile(params);
 
     final StoreLoader inputStoreLoader = new StoreLoader(storeName);
-    if (!inputStoreLoader.loadFromConfig(configFile)) {
+    if (!inputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
     }
-    DataStorePluginOptions storeOptions = inputStoreLoader.getDataStorePlugin();
+    final DataStorePluginOptions storeOptions = inputStoreLoader.getDataStorePlugin();
 
-    IndexStore indexStore = storeOptions.createIndexStore();
+    final IndexStore indexStore = storeOptions.createIndexStore();
 
-    Index existingIndex = indexStore.getIndex(indexName);
+    final Index existingIndex = indexStore.getIndex(indexName);
     if (existingIndex == null) {
       throw new TargetNotFoundException(indexName + " does not exist");
     }

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/cli/stats/CalculateStatCommand.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/cli/stats/CalculateStatCommand.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
+import com.beust.jcommander.internal.Console;
 
 @GeowaveOperation(name = "calc", parentOperation = StatsSection.class)
 @Parameters(
@@ -62,7 +63,8 @@ public class CalculateStatCommand extends AbstractStatsCommand<Void> {
   protected boolean performStatsCommand(
       final DataStorePluginOptions storeOptions,
       final InternalDataAdapter<?> adapter,
-      final StatsCommandLineOptions statsOptions) throws IOException {
+      final StatsCommandLineOptions statsOptions,
+      final Console console) throws IOException {
 
     try {
       final DataStore dataStore = storeOptions.createDataStore();
@@ -117,6 +119,10 @@ public class CalculateStatCommand extends AbstractStatsCommand<Void> {
     }
 
     return true;
+  }
+
+  public void setFieldName(String fieldName) {
+    this.fieldName = fieldName;
   }
 
   public List<String> getParameters() {

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/cli/stats/CompactStatsCommand.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/cli/stats/CompactStatsCommand.java
@@ -46,7 +46,7 @@ public class CompactStatsCommand extends DefaultOperation implements Command {
     // Attempt to load input store.
     if (inputStoreOptions == null) {
       final StoreLoader inputStoreLoader = new StoreLoader(inputStoreName);
-      if (!inputStoreLoader.loadFromConfig(getGeoWaveConfigFile(params))) {
+      if (!inputStoreLoader.loadFromConfig(getGeoWaveConfigFile(params), params.getConsole())) {
         throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
       }
       inputStoreOptions = inputStoreLoader.getDataStorePlugin();

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/cli/stats/ListStatsCommand.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/cli/stats/ListStatsCommand.java
@@ -23,10 +23,10 @@ import org.locationtech.geowave.core.store.adapter.statistics.InternalDataStatis
 import org.locationtech.geowave.core.store.cli.store.DataStorePluginOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
+import com.beust.jcommander.internal.Console;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
@@ -54,7 +54,8 @@ public class ListStatsCommand extends AbstractStatsCommand<String> implements Co
   protected boolean performStatsCommand(
       final DataStorePluginOptions storeOptions,
       final InternalDataAdapter<?> adapter,
-      final StatsCommandLineOptions statsOptions) throws IOException {
+      final StatsCommandLineOptions statsOptions,
+      final Console console) throws IOException {
 
     if (adapter == null) {
       throw new IOException("Provided adapter is null");
@@ -103,10 +104,14 @@ public class ListStatsCommand extends AbstractStatsCommand<String> implements Co
         }
       }
       retValue = builder.toString().trim();
-      JCommander.getConsole().println(retValue);
+      console.println(retValue);
     }
 
     return true;
+  }
+
+  public void setTypeName(final String typeName) {
+    this.typeName = typeName;
   }
 
   public List<String> getParameters() {

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/cli/stats/RecalculateStatsCommand.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/cli/stats/RecalculateStatsCommand.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
+import com.beust.jcommander.internal.Console;
 
 @GeowaveOperation(name = "recalc", parentOperation = StatsSection.class)
 @Parameters(commandDescription = "Recalculate the statistics of a data store")
@@ -54,7 +55,8 @@ public class RecalculateStatsCommand extends AbstractStatsCommand<Void> {
   protected boolean performStatsCommand(
       final DataStorePluginOptions storeOptions,
       final InternalDataAdapter<?> adapter,
-      final StatsCommandLineOptions statsOptions) throws IOException {
+      final StatsCommandLineOptions statsOptions,
+      final Console console) throws IOException {
 
     try {
       final DataStore dataStore = storeOptions.createDataStore();
@@ -103,6 +105,10 @@ public class RecalculateStatsCommand extends AbstractStatsCommand<Void> {
     }
 
     return true;
+  }
+
+  public void setTypeName(String typeName) {
+    this.typeName = typeName;
   }
 
   public List<String> getParameters() {

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/cli/stats/RemoveStatCommand.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/cli/stats/RemoveStatCommand.java
@@ -20,6 +20,7 @@ import org.locationtech.geowave.core.store.cli.store.DataStorePluginOptions;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
+import com.beust.jcommander.internal.Console;
 
 @GeowaveOperation(name = "rm", parentOperation = StatsSection.class)
 @Parameters(commandDescription = "Remove a statistic from a data store")
@@ -44,7 +45,8 @@ public class RemoveStatCommand extends AbstractStatsCommand<Void> {
   protected boolean performStatsCommand(
       final DataStorePluginOptions storeOptions,
       final InternalDataAdapter<?> adapter,
-      final StatsCommandLineOptions statsOptions) throws IOException {
+      final StatsCommandLineOptions statsOptions,
+      final Console console) throws IOException {
 
     // Remove the stat
     final DataStatisticsStore statStore = storeOptions.createDataStatisticsStore();

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/cli/stats/StatsSection.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/cli/stats/StatsSection.java
@@ -10,10 +10,10 @@ package org.locationtech.geowave.core.store.cli.stats;
 
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.DefaultOperation;
-import org.locationtech.geowave.core.cli.operations.GeowaveTopLevelSection;
+import org.locationtech.geowave.core.cli.operations.GeoWaveTopLevelSection;
 import com.beust.jcommander.Parameters;
 
-@GeowaveOperation(name = {"stat", "statistics"}, parentOperation = GeowaveTopLevelSection.class)
+@GeowaveOperation(name = {"stat", "statistics"}, parentOperation = GeoWaveTopLevelSection.class)
 @Parameters(commandDescription = "Commands to manage statistics")
 public class StatsSection extends DefaultOperation {
 }

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/cli/store/AbstractRemoveCommand.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/cli/store/AbstractRemoveCommand.java
@@ -63,7 +63,7 @@ public abstract class AbstractRemoveCommand extends ServiceEnabledCommand<String
     }
 
     // Write properties file
-    ConfigOptions.writeProperties(getGeoWaveConfigFile(params), existingProps);
+    ConfigOptions.writeProperties(getGeoWaveConfigFile(params), existingProps, params.getConsole());
     final int endSize = existingProps.size();
 
     if (endSize < startSize) {

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/cli/store/AddStoreCommand.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/cli/store/AddStoreCommand.java
@@ -109,7 +109,7 @@ public class AddStoreCommand extends ServiceEnabledCommand<String> {
     }
 
     if (pluginOptions.getFactoryOptions() != null) {
-      pluginOptions.getFactoryOptions().validatePluginOptions(existingProps);
+      pluginOptions.getFactoryOptions().validatePluginOptions(existingProps, params.getConsole());
     }
 
     // Save the store options.
@@ -125,7 +125,8 @@ public class AddStoreCommand extends ServiceEnabledCommand<String> {
         getGeoWaveConfigFile(),
         existingProps,
         pluginOptions.getFactoryOptions().getClass(),
-        getNamespace() + "." + DefaultPluginOptions.OPTS);
+        getNamespace() + "." + DefaultPluginOptions.OPTS,
+        params.getConsole());
 
     final StringBuilder builder = new StringBuilder();
     for (final Object key : existingProps.keySet()) {

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/cli/store/ClearStoreCommand.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/cli/store/ClearStoreCommand.java
@@ -69,7 +69,7 @@ public class ClearStoreCommand extends ServiceEnabledCommand<Void> {
 
     // Attempt to load input store.
     final StoreLoader inputStoreLoader = new StoreLoader(inputStoreName);
-    if (!inputStoreLoader.loadFromConfig(configFile)) {
+    if (!inputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
     }
     inputStoreOptions = inputStoreLoader.getDataStorePlugin();

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/cli/store/CopyConfigStoreCommand.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/cli/store/CopyConfigStoreCommand.java
@@ -57,6 +57,10 @@ public class CopyConfigStoreCommand extends DefaultOperation implements Command 
     return true;
   }
 
+  public void setNewPluginOptions(final DataStorePluginOptions newPluginOptions) {
+    this.newPluginOptions = newPluginOptions;
+  }
+
   @Override
   public void execute(final OperationParams params) {
 
@@ -85,7 +89,7 @@ public class CopyConfigStoreCommand extends DefaultOperation implements Command 
     }
 
     // Write properties file
-    ConfigOptions.writeProperties(getGeoWaveConfigFile(params), existingProps);
+    ConfigOptions.writeProperties(getGeoWaveConfigFile(params), existingProps, params.getConsole());
   }
 
   public List<String> getParameters() {

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/cli/store/CopyStoreCommand.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/cli/store/CopyStoreCommand.java
@@ -40,13 +40,13 @@ public class CopyStoreCommand extends DefaultOperation implements Command {
     final String inputStoreName = parameters.get(0);
     final String outputStoreName = parameters.get(1);
     final StoreLoader inputStoreLoader = new StoreLoader(inputStoreName);
-    if (!inputStoreLoader.loadFromConfig(configFile)) {
+    if (!inputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
     }
     inputStoreOptions = inputStoreLoader.getDataStorePlugin();
     // Attempt to load output store.
     final StoreLoader outputStoreLoader = new StoreLoader(outputStoreName);
-    if (!outputStoreLoader.loadFromConfig(configFile)) {
+    if (!outputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + outputStoreLoader.getStoreName());
     }
     outputStoreOptions = outputStoreLoader.getDataStorePlugin();

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/cli/store/ListStorePluginsCommand.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/cli/store/ListStorePluginsCommand.java
@@ -15,7 +15,6 @@ import org.locationtech.geowave.core.cli.api.OperationParams;
 import org.locationtech.geowave.core.cli.api.ServiceEnabledCommand;
 import org.locationtech.geowave.core.store.GeoWaveStoreFinder;
 import org.locationtech.geowave.core.store.StoreFactoryFamilySpi;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameters;
 
 @GeowaveOperation(name = "listplugins", parentOperation = StoreSection.class)
@@ -24,7 +23,7 @@ public class ListStorePluginsCommand extends ServiceEnabledCommand<String> {
 
   @Override
   public void execute(final OperationParams params) {
-    JCommander.getConsole().println(computeResults(params));
+    params.getConsole().println(computeResults(params));
   }
 
   @Override

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/cli/store/StoreLoader.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/cli/store/StoreLoader.java
@@ -26,7 +26,9 @@ import org.locationtech.geowave.core.store.api.DataStore;
 import org.locationtech.geowave.core.store.index.IndexStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
+import com.beust.jcommander.internal.Console;
 
 /**
  * This is a convenience class which sets up some obvious values in the OperationParams based on the
@@ -52,13 +54,26 @@ public class StoreLoader {
    * @return {@code true} if the configuration was successfully loaded
    */
   public boolean loadFromConfig(final File configFile) {
+    return loadFromConfig(configFile, new JCommander().getConsole());
+  }
+
+
+  /**
+   * Attempt to load the data store configuration from the config file.
+   *
+   * @param console the console to print output to
+   * @param configFile
+   * @return {@code true} if the configuration was successfully loaded
+   */
+  public boolean loadFromConfig(final File configFile, final Console console) {
 
     final String namespace = DataStorePluginOptions.getStoreNamespace(storeName);
 
     return loadFromConfig(
         ConfigOptions.loadProperties(configFile, "^" + namespace),
         namespace,
-        configFile);
+        configFile,
+        console);
   }
 
   /**
@@ -70,7 +85,8 @@ public class StoreLoader {
   public boolean loadFromConfig(
       final Properties props,
       final String namespace,
-      final File configFile) {
+      final File configFile,
+      final Console console) {
 
     dataStorePlugin = new DataStorePluginOptions();
 
@@ -99,7 +115,10 @@ public class StoreLoader {
                 String decryptedValue = value;
                 try {
                   decryptedValue =
-                      SecurityUtils.decryptHexEncodedValue(value, tokenFile.getAbsolutePath());
+                      SecurityUtils.decryptHexEncodedValue(
+                          value,
+                          tokenFile.getAbsolutePath(),
+                          console);
                 } catch (final Exception e) {
                   LOGGER.error(
                       "An error occurred encrypting specified password value: "

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/cli/store/StoreSection.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/cli/store/StoreSection.java
@@ -10,10 +10,10 @@ package org.locationtech.geowave.core.store.cli.store;
 
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.DefaultOperation;
-import org.locationtech.geowave.core.cli.operations.GeowaveTopLevelSection;
+import org.locationtech.geowave.core.cli.operations.GeoWaveTopLevelSection;
 import com.beust.jcommander.Parameters;
 
-@GeowaveOperation(name = "store", parentOperation = GeowaveTopLevelSection.class)
+@GeowaveOperation(name = "store", parentOperation = GeoWaveTopLevelSection.class)
 @Parameters(commandDescription = "Commands to manage GeoWave data stores")
 public class StoreSection extends DefaultOperation {
 }

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/cli/store/VersionCommand.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/cli/store/VersionCommand.java
@@ -17,7 +17,6 @@ import org.locationtech.geowave.core.cli.api.OperationParams;
 import org.locationtech.geowave.core.cli.api.ServiceEnabledCommand;
 import org.locationtech.geowave.core.store.operations.DataStoreOperations;
 import org.locationtech.geowave.core.store.server.ServerSideOperations;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
@@ -34,6 +33,10 @@ public class VersionCommand extends ServiceEnabledCommand<String> {
     computeResults(params);
   }
 
+  public void setParameters(final List<String> parameters) {
+    this.parameters = parameters;
+  }
+
   @Override
   public String computeResults(final OperationParams params) throws Exception {
     if (parameters.size() < 1) {
@@ -45,7 +48,7 @@ public class VersionCommand extends ServiceEnabledCommand<String> {
     final File configFile = getGeoWaveConfigFile(params);
 
     final StoreLoader inputStoreLoader = new StoreLoader(inputStoreName);
-    if (!inputStoreLoader.loadFromConfig(configFile)) {
+    if (!inputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       final String ret = "Cannot find store name: " + inputStoreLoader.getStoreName();
       throw new ParameterException(ret);
     }
@@ -56,14 +59,14 @@ public class VersionCommand extends ServiceEnabledCommand<String> {
       final DataStoreOperations ops = inputStoreOptions.createDataStoreOperations();
       if ((ops instanceof ServerSideOperations)
           && inputStoreOptions.getFactoryOptions().getStoreOptions().isServerSideLibraryEnabled()) {
-        JCommander.getConsole().println(
+        params.getConsole().println(
             "Looking up remote datastore version for type ["
                 + inputStoreOptions.getType()
                 + "] and name ["
                 + inputStoreName
                 + "]");
         final String version = "Version: " + ((ServerSideOperations) ops).getVersion();
-        JCommander.getConsole().println(version);
+        params.getConsole().println(version);
         return version;
       } else {
         final String ret1 =
@@ -72,9 +75,9 @@ public class VersionCommand extends ServiceEnabledCommand<String> {
                 + "] and name ["
                 + inputStoreName
                 + "] does not have a serverside library enabled.";
-        JCommander.getConsole().println(ret1);
+        params.getConsole().println(ret1);
         final String ret2 = "Commandline Version: " + VersionUtils.getVersion();
-        JCommander.getConsole().println(ret2);
+        params.getConsole().println(ret2);
         return ret1 + '\n' + ret2;
       }
     }

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/cli/type/DescribeTypeCommand.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/cli/type/DescribeTypeCommand.java
@@ -14,15 +14,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
-import org.locationtech.geowave.core.cli.api.Command;
-import org.locationtech.geowave.core.cli.api.DefaultOperation;
 import org.locationtech.geowave.core.cli.api.OperationParams;
 import org.locationtech.geowave.core.cli.api.ServiceEnabledCommand;
 import org.locationtech.geowave.core.cli.utils.ConsolePrinter;
 import org.locationtech.geowave.core.store.adapter.InternalAdapterStore;
 import org.locationtech.geowave.core.store.adapter.PersistentAdapterStore;
 import org.locationtech.geowave.core.store.api.DataTypeAdapter;
-import org.locationtech.geowave.core.store.api.QueryBuilder;
 import org.locationtech.geowave.core.store.cli.store.DataStorePluginOptions;
 import org.locationtech.geowave.core.store.cli.store.StoreLoader;
 import org.slf4j.Logger;
@@ -80,7 +77,7 @@ public class DescribeTypeCommand extends ServiceEnabledCommand<Void> {
     final File configFile = getGeoWaveConfigFile(params);
 
     final StoreLoader inputStoreLoader = new StoreLoader(inputStoreName);
-    if (!inputStoreLoader.loadFromConfig(configFile)) {
+    if (!inputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
     }
     inputStoreOptions = inputStoreLoader.getDataStorePlugin();
@@ -92,18 +89,18 @@ public class DescribeTypeCommand extends ServiceEnabledCommand<Void> {
         inputStoreOptions.createInternalAdapterStore();
     final DataTypeAdapter<?> type =
         adapterStore.getAdapter(internalAdapterStore.getAdapterId(typeName)).getAdapter();
-    Map<String, String> description = type.describe();
-    List<List<Object>> rows = new ArrayList<>();
-    for (Entry<String, String> entry : description.entrySet()) {
-      List<Object> row = new ArrayList<>();
+    final Map<String, String> description = type.describe();
+    final List<List<Object>> rows = new ArrayList<>();
+    for (final Entry<String, String> entry : description.entrySet()) {
+      final List<Object> row = new ArrayList<>();
       row.add(entry.getKey());
       row.add(entry.getValue());
       rows.add(row);
     }
-    List<String> headers = new ArrayList<>();
+    final List<String> headers = new ArrayList<>();
     headers.add("Property");
     headers.add("Value");
-    ConsolePrinter cp = new ConsolePrinter();
+    final ConsolePrinter cp = new ConsolePrinter();
     cp.print(headers, rows);
     return null;
   }

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/cli/type/ListTypesCommand.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/cli/type/ListTypesCommand.java
@@ -16,7 +16,6 @@ import org.locationtech.geowave.core.cli.api.OperationParams;
 import org.locationtech.geowave.core.cli.api.ServiceEnabledCommand;
 import org.locationtech.geowave.core.store.cli.store.DataStorePluginOptions;
 import org.locationtech.geowave.core.store.cli.store.StoreLoader;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
@@ -31,7 +30,7 @@ public class ListTypesCommand extends ServiceEnabledCommand<String> {
 
   @Override
   public void execute(final OperationParams params) {
-    JCommander.getConsole().println("Available types: " + computeResults(params));
+    params.getConsole().println("Available types: " + computeResults(params));
   }
 
   public List<String> getParameters() {
@@ -60,7 +59,7 @@ public class ListTypesCommand extends ServiceEnabledCommand<String> {
 
     // Attempt to load input store.
     final StoreLoader inputStoreLoader = new StoreLoader(inputStoreName);
-    if (!inputStoreLoader.loadFromConfig(configFile)) {
+    if (!inputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
     }
 

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/cli/type/RemoveTypeCommand.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/cli/type/RemoveTypeCommand.java
@@ -72,7 +72,7 @@ public class RemoveTypeCommand extends ServiceEnabledCommand<Void> {
     final File configFile = getGeoWaveConfigFile(params);
 
     final StoreLoader inputStoreLoader = new StoreLoader(inputStoreName);
-    if (!inputStoreLoader.loadFromConfig(configFile)) {
+    if (!inputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
     }
     inputStoreOptions = inputStoreLoader.getDataStorePlugin();

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/cli/type/TypeSection.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/cli/type/TypeSection.java
@@ -10,10 +10,10 @@ package org.locationtech.geowave.core.store.cli.type;
 
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.DefaultOperation;
-import org.locationtech.geowave.core.cli.operations.GeowaveTopLevelSection;
+import org.locationtech.geowave.core.cli.operations.GeoWaveTopLevelSection;
 import com.beust.jcommander.Parameters;
 
-@GeowaveOperation(name = "type", parentOperation = GeowaveTopLevelSection.class)
+@GeowaveOperation(name = "type", parentOperation = GeoWaveTopLevelSection.class)
 @Parameters(commandDescription = "Commands for managing types within a data store")
 public class TypeSection extends DefaultOperation {
 }

--- a/examples/java-api/src/main/java/org/locationtech/geowave/examples/spark/GeoWaveRDDExample.java
+++ b/examples/java-api/src/main/java/org/locationtech/geowave/examples/spark/GeoWaveRDDExample.java
@@ -26,8 +26,8 @@ import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.opengis.feature.simple.SimpleFeature;
 
-public class GeowaveRDDExample {
-  public GeowaveRDDExample() {}
+public class GeoWaveRDDExample {
+  public GeoWaveRDDExample() {}
 
   public boolean loadRddFromStore(final String[] args) {
     if (args.length < 1) {

--- a/extensions/adapters/raster/src/main/java/org/locationtech/geowave/adapter/raster/operations/DeletePyramidLevelCommand.java
+++ b/extensions/adapters/raster/src/main/java/org/locationtech/geowave/adapter/raster/operations/DeletePyramidLevelCommand.java
@@ -49,11 +49,11 @@ public class DeletePyramidLevelCommand extends DefaultOperation implements Comma
   private List<String> parameters = new ArrayList<>();
 
   @Parameter(names = "--level", description = "The raster pyramid level to delete", required = true)
-  private final Integer level = null;
+  private Integer level = null;
   @Parameter(
       names = "--coverage",
       description = "The raster coverage name (required if store has multiple coverages)")
-  private final String coverageName = null;
+  private String coverageName = null;
 
   private DataStorePluginOptions inputStoreOptions = null;
 
@@ -61,6 +61,14 @@ public class DeletePyramidLevelCommand extends DefaultOperation implements Comma
   @Override
   public void execute(final OperationParams params) throws Exception {
     run(params);
+  }
+
+  public void setLevel(final Integer level) {
+    this.level = level;
+  }
+
+  public void setCoverageName(final String coverageName) {
+    this.coverageName = coverageName;
   }
 
   public void run(final OperationParams params) {
@@ -76,7 +84,7 @@ public class DeletePyramidLevelCommand extends DefaultOperation implements Comma
 
     // Attempt to load input store.
     final StoreLoader inputStoreLoader = new StoreLoader(inputStoreName);
-    if (!inputStoreLoader.loadFromConfig(configFile)) {
+    if (!inputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
     }
     inputStoreOptions = inputStoreLoader.getDataStorePlugin();

--- a/extensions/adapters/raster/src/main/java/org/locationtech/geowave/adapter/raster/operations/RasterSection.java
+++ b/extensions/adapters/raster/src/main/java/org/locationtech/geowave/adapter/raster/operations/RasterSection.java
@@ -10,10 +10,10 @@ package org.locationtech.geowave.adapter.raster.operations;
 
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.DefaultOperation;
-import org.locationtech.geowave.core.cli.operations.GeowaveTopLevelSection;
+import org.locationtech.geowave.core.cli.operations.GeoWaveTopLevelSection;
 import com.beust.jcommander.Parameters;
 
-@GeowaveOperation(name = "raster", parentOperation = GeowaveTopLevelSection.class)
+@GeowaveOperation(name = "raster", parentOperation = GeoWaveTopLevelSection.class)
 @Parameters(commandDescription = "Operations to perform transformations on raster data in GeoWave")
 public class RasterSection extends DefaultOperation {
 }

--- a/extensions/adapters/raster/src/main/java/org/locationtech/geowave/adapter/raster/operations/ResizeMRCommand.java
+++ b/extensions/adapters/raster/src/main/java/org/locationtech/geowave/adapter/raster/operations/ResizeMRCommand.java
@@ -72,14 +72,14 @@ public class ResizeMRCommand extends DefaultOperation implements Command {
 
     // Attempt to load input store.
     final StoreLoader inputStoreLoader = new StoreLoader(inputStoreName);
-    if (!inputStoreLoader.loadFromConfig(configFile)) {
+    if (!inputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
     }
     inputStoreOptions = inputStoreLoader.getDataStorePlugin();
 
     // Attempt to load output store.
     final StoreLoader outputStoreLoader = new StoreLoader(outputStoreName);
-    if (!outputStoreLoader.loadFromConfig(configFile)) {
+    if (!outputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + outputStoreLoader.getStoreName());
     }
     outputStoreOptions = outputStoreLoader.getDataStorePlugin();

--- a/extensions/adapters/vector/src/main/java/org/locationtech/geowave/adapter/vector/cli/VectorSection.java
+++ b/extensions/adapters/vector/src/main/java/org/locationtech/geowave/adapter/vector/cli/VectorSection.java
@@ -10,10 +10,10 @@ package org.locationtech.geowave.adapter.vector.cli;
 
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.DefaultOperation;
-import org.locationtech.geowave.core.cli.operations.GeowaveTopLevelSection;
+import org.locationtech.geowave.core.cli.operations.GeoWaveTopLevelSection;
 import com.beust.jcommander.Parameters;
 
-@GeowaveOperation(name = "vector", parentOperation = GeowaveTopLevelSection.class)
+@GeowaveOperation(name = "vector", parentOperation = GeoWaveTopLevelSection.class)
 @Parameters(commandDescription = "Vector data operations")
 public class VectorSection extends DefaultOperation {
 }

--- a/extensions/adapters/vector/src/main/java/org/locationtech/geowave/adapter/vector/delete/CQLDelete.java
+++ b/extensions/adapters/vector/src/main/java/org/locationtech/geowave/adapter/vector/delete/CQLDelete.java
@@ -67,6 +67,14 @@ public class CQLDelete extends DefaultOperation implements Command {
       description = "Print out additional info for debug purposes")
   private boolean debug = false;
 
+  public void setParameters(final List<String> parameters) {
+    this.parameters = parameters;
+  }
+
+  public void setDebug(final boolean debug) {
+    this.debug = debug;
+  }
+
   @Override
   public void execute(final OperationParams params) throws ParseException {
     if (debug) {
@@ -87,7 +95,7 @@ public class CQLDelete extends DefaultOperation implements Command {
 
     // Attempt to load store.
     final StoreLoader storeOptions = new StoreLoader(storeName);
-    if (!storeOptions.loadFromConfig(configFile)) {
+    if (!storeOptions.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + storeOptions.getStoreName());
     }
 

--- a/extensions/adapters/vector/src/main/java/org/locationtech/geowave/adapter/vector/export/VectorLocalExportCommand.java
+++ b/extensions/adapters/vector/src/main/java/org/locationtech/geowave/adapter/vector/export/VectorLocalExportCommand.java
@@ -37,7 +37,6 @@ import org.locationtech.geowave.core.store.cli.store.StoreLoader;
 import org.locationtech.geowave.core.store.index.IndexStore;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
@@ -67,7 +66,7 @@ public class VectorLocalExportCommand extends DefaultOperation implements Comman
     // Config file
     final File configFile = getGeoWaveConfigFile(params);
     final StoreLoader inputStoreLoader = new StoreLoader(storeName);
-    if (!inputStoreLoader.loadFromConfig(configFile)) {
+    if (!inputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
     }
     inputStoreOptions = inputStoreLoader.getDataStorePlugin();
@@ -91,10 +90,10 @@ public class VectorLocalExportCommand extends DefaultOperation implements Comman
           final short adapterId = internalAdapterStore.getAdapterId(typeName);
           final InternalDataAdapter<?> internalDataAdapter = adapterStore.getAdapter(adapterId);
           if (internalDataAdapter == null) {
-            JCommander.getConsole().println("Type '" + typeName + "' not found");
+            params.getConsole().println("Type '" + typeName + "' not found");
             continue;
           } else if (!(internalDataAdapter.getAdapter() instanceof GeotoolsFeatureDataAdapter)) {
-            JCommander.getConsole().println(
+            params.getConsole().println(
                 "Type '"
                     + typeName
                     + "' does not support vector export. Instance of "
@@ -114,20 +113,20 @@ public class VectorLocalExportCommand extends DefaultOperation implements Comman
         adapters.close();
       }
       if (featureAdapters.isEmpty()) {
-        JCommander.getConsole().println("Unable to find any vector data types in store");
+        params.getConsole().println("Unable to find any vector data types in store");
       }
       Index queryIndex = null;
       if (options.getIndexName() != null) {
         queryIndex = indexStore.getIndex(options.getIndexName());
         if (queryIndex == null) {
-          JCommander.getConsole().println(
+          params.getConsole().println(
               "Unable to find index '" + options.getIndexName() + "' in store");
           return;
         }
       }
       for (final GeotoolsFeatureDataAdapter adapter : featureAdapters) {
         final SimpleFeatureType sft = adapter.getFeatureType();
-        JCommander.getConsole().println("Exporting type '" + sft.getTypeName() + "'");
+        params.getConsole().println("Exporting type '" + sft.getTypeName() + "'");
         final VectorQueryBuilder bldr = VectorQueryBuilder.newBuilder();
 
         if (options.getIndexName() != null) {
@@ -155,7 +154,7 @@ public class VectorLocalExportCommand extends DefaultOperation implements Comman
                 avList.add(av);
               }
             }
-            JCommander.getConsole().println(
+            params.getConsole().println(
                 "Exported "
                     + (avList.size() + (iteration * options.getBatchSize()))
                     + " features from '"
@@ -166,7 +165,7 @@ public class VectorLocalExportCommand extends DefaultOperation implements Comman
             dfw.append(simpleFeatureCollection);
             dfw.flush();
           }
-          JCommander.getConsole().println("Finished exporting '" + sft.getTypeName() + "'");
+          params.getConsole().println("Finished exporting '" + sft.getTypeName() + "'");
         }
       }
     }

--- a/extensions/adapters/vector/src/main/java/org/locationtech/geowave/adapter/vector/export/VectorMRExportCommand.java
+++ b/extensions/adapters/vector/src/main/java/org/locationtech/geowave/adapter/vector/export/VectorMRExportCommand.java
@@ -61,14 +61,19 @@ public class VectorMRExportCommand extends DefaultOperation implements Command {
     // Attempt to load store.
     if (storeOptions == null) {
       final StoreLoader storeLoader = new StoreLoader(storeName);
-      if (!storeLoader.loadFromConfig(configFile)) {
+      if (!storeLoader.loadFromConfig(configFile, params.getConsole())) {
         throw new ParameterException("Cannot find store name: " + storeLoader.getStoreName());
       }
       storeOptions = storeLoader.getDataStorePlugin();
     }
 
     final VectorMRExportJobRunner vectorRunner =
-        new VectorMRExportJobRunner(storeOptions, mrOptions, hdfsHostPort, hdfsPath);
+        new VectorMRExportJobRunner(
+            storeOptions,
+            mrOptions,
+            hdfsHostPort,
+            hdfsPath,
+            params.getConsole());
     return vectorRunner;
   }
 

--- a/extensions/adapters/vector/src/main/java/org/locationtech/geowave/adapter/vector/export/VectorMRExportJobRunner.java
+++ b/extensions/adapters/vector/src/main/java/org/locationtech/geowave/adapter/vector/export/VectorMRExportJobRunner.java
@@ -38,7 +38,7 @@ import org.locationtech.geowave.mapreduce.GeoWaveConfiguratorBase;
 import org.locationtech.geowave.mapreduce.input.GeoWaveInputFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.beust.jcommander.JCommander;
+import com.beust.jcommander.internal.Console;
 
 public class VectorMRExportJobRunner extends Configured implements Tool {
   private static final Logger LOGGER = LoggerFactory.getLogger(VectorMRExportCommand.class);
@@ -48,16 +48,19 @@ public class VectorMRExportJobRunner extends Configured implements Tool {
   private final VectorMRExportOptions mrOptions;
   private final String hdfsHostPort;
   private final String hdfsPath;
+  private final Console console;
 
   public VectorMRExportJobRunner(
       final DataStorePluginOptions storeOptions,
       final VectorMRExportOptions mrOptions,
       final String hdfsHostPort,
-      final String hdfsPath) {
+      final String hdfsPath,
+      final Console console) {
     this.storeOptions = storeOptions;
     this.mrOptions = mrOptions;
     this.hdfsHostPort = hdfsHostPort;
     this.hdfsPath = hdfsPath;
+    this.console = console;
   }
 
   /** Main method to execute the MapReduce analytic. */
@@ -97,15 +100,14 @@ public class VectorMRExportJobRunner extends Configured implements Tool {
     if (mrOptions.getIndexName() != null) {
       final Index index = indexStore.getIndex(mrOptions.getIndexName());
       if (index == null) {
-        JCommander.getConsole().println(
-            "Unable to find index '" + mrOptions.getIndexName() + "' in store");
+        console.println("Unable to find index '" + mrOptions.getIndexName() + "' in store");
         return -1;
       }
       bldr.indexName(mrOptions.getIndexName());
     }
     if (mrOptions.getCqlFilter() != null) {
       if ((typeNames == null) || (typeNames.size() != 1)) {
-        JCommander.getConsole().println("Exactly one type is expected when using CQL filter");
+        console.println("Exactly one type is expected when using CQL filter");
         return -1;
       }
       final String typeName = typeNames.get(0);
@@ -114,11 +116,11 @@ public class VectorMRExportJobRunner extends Configured implements Tool {
       final InternalDataAdapter<?> adapter =
           storeOptions.createAdapterStore().getAdapter(internalAdpaterId);
       if (adapter == null) {
-        JCommander.getConsole().println("Type '" + typeName + "' not found");
+        console.println("Type '" + typeName + "' not found");
         return -1;
       }
       if (!(adapter.getAdapter() instanceof GeotoolsFeatureDataAdapter)) {
-        JCommander.getConsole().println("Type '" + typeName + "' does not support vector export");
+        console.println("Type '" + typeName + "' does not support vector export");
 
         return -1;
       }

--- a/extensions/adapters/vector/src/main/java/org/locationtech/geowave/adapter/vector/query/GWQLQuery.java
+++ b/extensions/adapters/vector/src/main/java/org/locationtech/geowave/adapter/vector/query/GWQLQuery.java
@@ -54,7 +54,19 @@ public class GWQLQuery extends DefaultOperation implements Command {
       names = "--debug",
       required = false,
       description = "Print out additional info for debug purposes")
-  private final boolean debug = false;
+  private boolean debug = false;
+
+  public void setOutputFormat(final String outputFormat) {
+    this.outputFormat = outputFormat;
+  }
+
+  public void setDebug(final boolean debug) {
+    this.debug = debug;
+  }
+
+  public void setParameters(final List<String> parameters) {
+    this.parameters = parameters;
+  }
 
   @Override
   public boolean prepare(final OperationParams params) {
@@ -97,7 +109,7 @@ public class GWQLQuery extends DefaultOperation implements Command {
     if (statement.getStoreName() != null) {
       final File configFile = (File) params.getContext().get(ConfigOptions.PROPERTIES_FILE_CONTEXT);
       final StoreLoader storeLoader = new StoreLoader(statement.getStoreName());
-      if (!storeLoader.loadFromConfig(configFile)) {
+      if (!storeLoader.loadFromConfig(configFile, params.getConsole())) {
         throw new ParameterException("Cannot find store name: " + storeLoader.getStoreName());
       }
       storeOptions = storeLoader.getDataStorePlugin();
@@ -106,7 +118,7 @@ public class GWQLQuery extends DefaultOperation implements Command {
     }
     final StopWatch stopWatch = new StopWatch();
     stopWatch.start();
-    ResultSet results = statement.execute(storeOptions.createDataStore());
+    final ResultSet results = statement.execute(storeOptions.createDataStore());
     stopWatch.stop();
     output.output(results);
     results.close();

--- a/extensions/cli/debug/src/main/java/org/locationtech/geowave/cli/debug/AbstractGeoWaveQuery.java
+++ b/extensions/cli/debug/src/main/java/org/locationtech/geowave/cli/debug/AbstractGeoWaveQuery.java
@@ -44,6 +44,14 @@ public abstract class AbstractGeoWaveQuery extends DefaultOperation implements C
   @Parameter(names = "--debug", description = "Print out additional info for debug purposes")
   private boolean debug = false;
 
+  public void setParameters(final List<String> parameters) {
+    this.parameters = parameters;
+  }
+
+  public void setDebug(final boolean debug) {
+    this.debug = debug;
+  }
+
   @Override
   public void execute(final OperationParams params) throws ParseException {
     final StopWatch stopWatch = new StopWatch();
@@ -57,7 +65,7 @@ public abstract class AbstractGeoWaveQuery extends DefaultOperation implements C
 
     // Attempt to load store.
     final StoreLoader storeOptions = new StoreLoader(storeName);
-    if (!storeOptions.loadFromConfig(getGeoWaveConfigFile(params))) {
+    if (!storeOptions.loadFromConfig(getGeoWaveConfigFile(params), params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + storeOptions.getStoreName());
     }
 

--- a/extensions/cli/debug/src/main/java/org/locationtech/geowave/cli/debug/DebugSection.java
+++ b/extensions/cli/debug/src/main/java/org/locationtech/geowave/cli/debug/DebugSection.java
@@ -10,10 +10,10 @@ package org.locationtech.geowave.cli.debug;
 
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.DefaultOperation;
-import org.locationtech.geowave.core.cli.operations.GeowaveTopLevelSection;
+import org.locationtech.geowave.core.cli.operations.GeoWaveTopLevelSection;
 import com.beust.jcommander.Parameters;
 
-@GeowaveOperation(name = "debug", parentOperation = GeowaveTopLevelSection.class)
+@GeowaveOperation(name = "debug", parentOperation = GeoWaveTopLevelSection.class)
 @Parameters(commandDescription = "Scratchpad for geowave ops")
 public class DebugSection extends DefaultOperation {
 }

--- a/extensions/cli/debug/src/main/java/org/locationtech/geowave/cli/debug/MinimalFullTable.java
+++ b/extensions/cli/debug/src/main/java/org/locationtech/geowave/cli/debug/MinimalFullTable.java
@@ -49,6 +49,10 @@ public class MinimalFullTable extends DefaultOperation implements Command {
   @Parameter(names = "--indexId", required = true, description = "The name of the index (optional)")
   private String indexId;
 
+  public void setParameters(final List<String> parameters) {
+    this.parameters = parameters;
+  }
+
   @Override
   public void execute(final OperationParams params) throws ParseException {
     final StopWatch stopWatch = new StopWatch();
@@ -62,7 +66,7 @@ public class MinimalFullTable extends DefaultOperation implements Command {
 
     // Attempt to load store.
     final StoreLoader storeOptions = new StoreLoader(storeName);
-    if (!storeOptions.loadFromConfig(getGeoWaveConfigFile(params))) {
+    if (!storeOptions.loadFromConfig(getGeoWaveConfigFile(params), params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + storeOptions.getStoreName());
     }
 

--- a/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/ConfigGeoServerCommand.java
+++ b/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/ConfigGeoServerCommand.java
@@ -101,7 +101,7 @@ public class ConfigGeoServerCommand extends ServiceEnabledCommand<String> {
 
   @Override
   public void execute(final OperationParams params) throws Exception {
-    JCommander.getConsole().println(computeResults(params));
+    params.getConsole().println(computeResults(params));
   }
 
   @Override
@@ -166,7 +166,7 @@ public class ConfigGeoServerCommand extends ServiceEnabledCommand<String> {
 
     final String programName = StringUtils.join(nameArray, " ");
     jc.setProgramName(programName);
-    jc.usage(builder);
+    jc.getUsageFormatter().usage(builder);
 
     // Trim excess newlines.
     final String operations = builder.toString().trim();
@@ -196,7 +196,7 @@ public class ConfigGeoServerCommand extends ServiceEnabledCommand<String> {
     }
 
     jc.setProgramName(programName);
-    jc.usage(builder);
+    jc.getUsageFormatter().usage(builder);
     builder.append("\n\n");
 
     return builder.toString().trim();
@@ -236,7 +236,8 @@ public class ConfigGeoServerCommand extends ServiceEnabledCommand<String> {
         getGeoWaveConfigFile(params),
         existingProps,
         this.getClass(),
-        GEOSERVER_NAMESPACE_PREFIX);
+        GEOSERVER_NAMESPACE_PREFIX,
+        params.getConsole());
     GeoServerRestClient.invalidateInstance();
 
     // generate a return for rest calls

--- a/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/GeoServerCommand.java
+++ b/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/GeoServerCommand.java
@@ -25,7 +25,9 @@ public abstract class GeoServerCommand<T> extends ServiceEnabledCommand<T> {
     if (geoserverClient == null) {
       // Create the rest client
       geoserverClient =
-          GeoServerRestClient.getInstance(new GeoServerConfig(getGeoWaveConfigFile(params)));
+          GeoServerRestClient.getInstance(
+              new GeoServerConfig(getGeoWaveConfigFile(params), params.getConsole()),
+              params.getConsole());
     }
 
     // Successfully prepared

--- a/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/GeoServerConfig.java
+++ b/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/GeoServerConfig.java
@@ -21,6 +21,7 @@ import org.locationtech.geowave.core.cli.operations.config.security.utils.Securi
 import org.locationtech.geowave.core.cli.utils.URLUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.beust.jcommander.internal.Console;
 
 public class GeoServerConfig {
   private static final Logger LOGGER = LoggerFactory.getLogger(GeoServerConfig.class);
@@ -48,7 +49,7 @@ public class GeoServerConfig {
    *
    * @param propFile
    */
-  public GeoServerConfig(final File propFile) {
+  public GeoServerConfig(final File propFile, final Console console) {
     this.propFile = propFile;
 
     if ((propFile != null) && propFile.exists()) {
@@ -81,7 +82,11 @@ public class GeoServerConfig {
       try {
         final File resourceTokenFile = SecurityUtils.getFormattedTokenKeyFileForConfig(propFile);
         // if password in config props is encrypted, need to decrypt it
-        pass = SecurityUtils.decryptHexEncodedValue(pass, resourceTokenFile.getCanonicalPath());
+        pass =
+            SecurityUtils.decryptHexEncodedValue(
+                pass,
+                resourceTokenFile.getCanonicalPath(),
+                console);
       } catch (final Exception e) {
         LOGGER.error("An error occurred decrypting password: " + e.getLocalizedMessage(), e);
       }
@@ -95,15 +100,15 @@ public class GeoServerConfig {
     }
 
     if (update) {
-      ConfigOptions.writeProperties(propFile, gsConfigProperties);
+      ConfigOptions.writeProperties(propFile, gsConfigProperties, console);
 
       LOGGER.info("GeoServer Config Saved");
     }
   }
 
   /** Secondary no-arg constructor for direct-access testing */
-  public GeoServerConfig() {
-    this(ConfigOptions.getDefaultPropertyFile());
+  public GeoServerConfig(final Console console) {
+    this(ConfigOptions.getDefaultPropertyFile(console), console);
   }
 
   public String getUrl() {

--- a/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/GeoServerRestClient.java
+++ b/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/GeoServerRestClient.java
@@ -75,6 +75,7 @@ import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import com.beust.jcommander.ParameterException;
+import com.beust.jcommander.internal.Console;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 
@@ -89,20 +90,28 @@ public class GeoServerRestClient {
   }
 
   private final GeoServerConfig config;
+  private final Console console;
   private WebTarget webTarget = null;
 
-  private GeoServerRestClient(final GeoServerConfig config) {
+  private GeoServerRestClient(final GeoServerConfig config, final Console console) {
     this.config = config;
+    this.console = console;
   }
 
-  private GeoServerRestClient(final GeoServerConfig config, final WebTarget webTarget) {
+  private GeoServerRestClient(
+      final GeoServerConfig config,
+      final WebTarget webTarget,
+      final Console console) {
     this.config = config;
     this.webTarget = webTarget;
+    this.console = console;
   }
 
-  public static GeoServerRestClient getInstance(final GeoServerConfig config) {
+  public static GeoServerRestClient getInstance(
+      final GeoServerConfig config,
+      final Console console) {
     if (SINGLETON_INSTANCE == null) {
-      SINGLETON_INSTANCE = new GeoServerRestClient(config);
+      SINGLETON_INSTANCE = new GeoServerRestClient(config, console);
     }
     return SINGLETON_INSTANCE;
   }
@@ -280,7 +289,8 @@ public class GeoServerRestClient {
           configValue =
               SecurityUtils.decryptHexEncodedValue(
                   configValue,
-                  resourceTokenFile.getCanonicalPath());
+                  resourceTokenFile.getCanonicalPath(),
+                  console);
           return configValue;
         } catch (final Exception e) {
           LOGGER.error("An error occurred decrypting password: " + e.getLocalizedMessage(), e);
@@ -1449,7 +1459,7 @@ public class GeoServerRestClient {
 
   public DataStorePluginOptions getStorePlugin(final String storeName) {
     final StoreLoader inputStoreLoader = new StoreLoader(storeName);
-    if (!inputStoreLoader.loadFromConfig(config.getPropFile())) {
+    if (!inputStoreLoader.loadFromConfig(config.getPropFile(), console)) {
       throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
     }
 

--- a/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/GeoServerSection.java
+++ b/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/GeoServerSection.java
@@ -10,10 +10,10 @@ package org.locationtech.geowave.cli.geoserver;
 
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.DefaultOperation;
-import org.locationtech.geowave.core.cli.operations.GeowaveTopLevelSection;
+import org.locationtech.geowave.core.cli.operations.GeoWaveTopLevelSection;
 import com.beust.jcommander.Parameters;
 
-@GeowaveOperation(name = {"gs", "geoserver"}, parentOperation = GeowaveTopLevelSection.class)
+@GeowaveOperation(name = {"gs", "geoserver"}, parentOperation = GeoWaveTopLevelSection.class)
 @Parameters(commandDescription = "Commands that manage geoserver data stores and layers")
 public class GeoServerSection extends DefaultOperation {
 }

--- a/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/coverage/GeoServerAddCoverageCommand.java
+++ b/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/coverage/GeoServerAddCoverageCommand.java
@@ -15,7 +15,6 @@ import javax.ws.rs.core.Response.Status;
 import org.locationtech.geowave.cli.geoserver.GeoServerCommand;
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.OperationParams;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
@@ -30,13 +29,13 @@ public class GeoServerAddCoverageCommand extends GeoServerCommand<String> {
   private String cvgstore = null;
 
   @Parameter(description = "<coverage name>")
-  private List<String> parameters = new ArrayList<String>();
+  private List<String> parameters = new ArrayList<>();
 
   private String cvgName = null;
 
   @Override
   public void execute(final OperationParams params) throws Exception {
-    JCommander.getConsole().println(computeResults(params));
+    params.getConsole().println(computeResults(params));
   }
 
   @Override
@@ -70,5 +69,13 @@ public class GeoServerAddCoverageCommand extends GeoServerCommand<String> {
             + "\nGeoServer Response Code = "
             + addLayerResponse.getStatus();
     return handleError(addLayerResponse, errorMessage);
+  }
+
+  public void setCvgstore(String cvgstore) {
+    this.cvgstore = cvgstore;
+  }
+
+  public void setParameters(List<String> parameters) {
+    this.parameters = parameters;
   }
 }

--- a/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/coverage/GeoServerGetCoverageCommand.java
+++ b/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/coverage/GeoServerGetCoverageCommand.java
@@ -15,7 +15,6 @@ import javax.ws.rs.core.Response.Status;
 import org.locationtech.geowave.cli.geoserver.GeoServerCommand;
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.OperationParams;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
@@ -37,7 +36,7 @@ public class GeoServerGetCoverageCommand extends GeoServerCommand<String> {
 
   @Override
   public void execute(final OperationParams params) throws Exception {
-    JCommander.getConsole().println(computeResults(params));
+    params.getConsole().println(computeResults(params));
   }
 
   @Override
@@ -67,5 +66,13 @@ public class GeoServerGetCoverageCommand extends GeoServerCommand<String> {
             + "\nGeoServer Response Code = "
             + getCvgResponse.getStatus();
     return handleError(getCvgResponse, errorMessage);
+  }
+
+  public void setCvgstore(final String cvgstore) {
+    this.cvgstore = cvgstore;
+  }
+
+  public void setParameters(final List<String> parameters) {
+    this.parameters = parameters;
   }
 }

--- a/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/coverage/GeoServerListCoveragesCommand.java
+++ b/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/coverage/GeoServerListCoveragesCommand.java
@@ -15,7 +15,6 @@ import javax.ws.rs.core.Response.Status;
 import org.locationtech.geowave.cli.geoserver.GeoServerCommand;
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.OperationParams;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
@@ -35,7 +34,7 @@ public class GeoServerListCoveragesCommand extends GeoServerCommand<String> {
 
   @Override
   public void execute(final OperationParams params) throws Exception {
-    JCommander.getConsole().println(computeResults(params));
+    params.getConsole().println(computeResults(params));
   }
 
   @Override
@@ -65,5 +64,9 @@ public class GeoServerListCoveragesCommand extends GeoServerCommand<String> {
             + "\nGeoServer Response Code = "
             + getCvgStoreResponse.getStatus();
     return handleError(getCvgStoreResponse, errorMessage);
+  }
+
+  public void setParameters(List<String> parameters) {
+    this.parameters = parameters;
   }
 }

--- a/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/coverage/GeoServerRemoveCoverageCommand.java
+++ b/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/coverage/GeoServerRemoveCoverageCommand.java
@@ -15,7 +15,6 @@ import javax.ws.rs.core.Response.Status;
 import org.locationtech.geowave.cli.geoserver.GeoServerRemoveCommand;
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.OperationParams;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
@@ -30,13 +29,13 @@ public class GeoServerRemoveCoverageCommand extends GeoServerRemoveCommand<Strin
   private String cvgstore = null;
 
   @Parameter(description = "<coverage name>")
-  private List<String> parameters = new ArrayList<String>();
+  private List<String> parameters = new ArrayList<>();
 
   private String cvgName = null;
 
   @Override
   public void execute(final OperationParams params) throws Exception {
-    JCommander.getConsole().println(computeResults(params));
+    params.getConsole().println(computeResults(params));
   }
 
   @Override
@@ -64,5 +63,13 @@ public class GeoServerRemoveCoverageCommand extends GeoServerRemoveCommand<Strin
             + "\nGeoServer Response Code = "
             + getCvgResponse.getStatus();
     return handleError(getCvgResponse, errorMessage);
+  }
+
+  public void setCvgstore(String cvgstore) {
+    this.cvgstore = cvgstore;
+  }
+
+  public void setParameters(List<String> parameters) {
+    this.parameters = parameters;
   }
 }

--- a/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/cvstore/GeoServerAddCoverageStoreCommand.java
+++ b/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/cvstore/GeoServerAddCoverageStoreCommand.java
@@ -15,7 +15,6 @@ import javax.ws.rs.core.Response.Status;
 import org.locationtech.geowave.cli.geoserver.GeoServerCommand;
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.OperationParams;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
@@ -53,13 +52,33 @@ public class GeoServerAddCoverageStoreCommand extends GeoServerCommand<String> {
   private Boolean scaleTo8Bit = null;
 
   @Parameter(description = "<GeoWave store name>")
-  private List<String> parameters = new ArrayList<String>();
+  private List<String> parameters = new ArrayList<>();
 
   private String gwStore = null;
 
+  public void setCoverageStore(final String coverageStore) {
+    this.coverageStore = coverageStore;
+  }
+
+  public void setEqualizeHistogramOverride(final Boolean equalizeHistogramOverride) {
+    this.equalizeHistogramOverride = equalizeHistogramOverride;
+  }
+
+  public void setInterpolationOverride(final String interpolationOverride) {
+    this.interpolationOverride = interpolationOverride;
+  }
+
+  public void setScaleTo8Bit(final Boolean scaleTo8Bit) {
+    this.scaleTo8Bit = scaleTo8Bit;
+  }
+
+  public void setParameters(final List<String> parameters) {
+    this.parameters = parameters;
+  }
+
   @Override
   public void execute(final OperationParams params) throws Exception {
-    JCommander.getConsole().println(computeResults(params));
+    params.getConsole().println(computeResults(params));
   }
 
   @Override

--- a/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/cvstore/GeoServerGetCoverageStoreCommand.java
+++ b/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/cvstore/GeoServerGetCoverageStoreCommand.java
@@ -15,7 +15,6 @@ import javax.ws.rs.core.Response.Status;
 import org.locationtech.geowave.cli.geoserver.GeoServerCommand;
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.OperationParams;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
@@ -34,7 +33,11 @@ public class GeoServerGetCoverageStoreCommand extends GeoServerCommand<String> {
 
   @Override
   public void execute(final OperationParams params) throws Exception {
-    JCommander.getConsole().println(computeResults(params));
+    params.getConsole().println(computeResults(params));
+  }
+
+  public void setParameters(List<String> parameters) {
+    this.parameters = parameters;
   }
 
   @Override

--- a/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/cvstore/GeoServerListCoverageStoresCommand.java
+++ b/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/cvstore/GeoServerListCoverageStoresCommand.java
@@ -13,7 +13,6 @@ import javax.ws.rs.core.Response.Status;
 import org.locationtech.geowave.cli.geoserver.GeoServerCommand;
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.OperationParams;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import net.sf.json.JSONArray;
@@ -27,7 +26,7 @@ public class GeoServerListCoverageStoresCommand extends GeoServerCommand<String>
 
   @Override
   public void execute(final OperationParams params) throws Exception {
-    JCommander.getConsole().println(computeResults(params));
+    params.getConsole().println(computeResults(params));
   }
 
   @Override

--- a/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/cvstore/GeoServerRemoveCoverageStoreCommand.java
+++ b/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/cvstore/GeoServerRemoveCoverageStoreCommand.java
@@ -15,7 +15,6 @@ import javax.ws.rs.core.Response.Status;
 import org.locationtech.geowave.cli.geoserver.GeoServerRemoveCommand;
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.OperationParams;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
@@ -33,7 +32,11 @@ public class GeoServerRemoveCoverageStoreCommand extends GeoServerRemoveCommand<
 
   @Override
   public void execute(final OperationParams params) throws Exception {
-    JCommander.getConsole().println(computeResults(params));
+    params.getConsole().println(computeResults(params));
+  }
+
+  public void setParameters(final List<String> parameters) {
+    this.parameters = parameters;
   }
 
   @Override

--- a/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/datastore/GeoServerAddDatastoreCommand.java
+++ b/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/datastore/GeoServerAddDatastoreCommand.java
@@ -15,7 +15,6 @@ import javax.ws.rs.core.Response.Status;
 import org.locationtech.geowave.cli.geoserver.GeoServerCommand;
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.OperationParams;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
@@ -36,7 +35,15 @@ public class GeoServerAddDatastoreCommand extends GeoServerCommand<String> {
 
   @Override
   public void execute(final OperationParams params) throws Exception {
-    JCommander.getConsole().println(computeResults(params));
+    params.getConsole().println(computeResults(params));
+  }
+
+  public void setDatastore(final String datastore) {
+    this.datastore = datastore;
+  }
+
+  public void setParameters(final List<String> parameters) {
+    this.parameters = parameters;
   }
 
   @Override

--- a/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/datastore/GeoServerGetDatastoreCommand.java
+++ b/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/datastore/GeoServerGetDatastoreCommand.java
@@ -15,7 +15,6 @@ import javax.ws.rs.core.Response.Status;
 import org.locationtech.geowave.cli.geoserver.GeoServerCommand;
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.OperationParams;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
@@ -34,7 +33,11 @@ public class GeoServerGetDatastoreCommand extends GeoServerCommand<String> {
 
   @Override
   public void execute(final OperationParams params) throws Exception {
-    JCommander.getConsole().println(computeResults(params));
+    params.getConsole().println(computeResults(params));
+  }
+
+  public void setParameters(List<String> parameters) {
+    this.parameters = parameters;
   }
 
   @Override

--- a/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/datastore/GeoServerGetStoreAdapterCommand.java
+++ b/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/datastore/GeoServerGetStoreAdapterCommand.java
@@ -13,7 +13,6 @@ import java.util.List;
 import org.locationtech.geowave.cli.geoserver.GeoServerCommand;
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.OperationParams;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
@@ -26,13 +25,17 @@ public class GeoServerGetStoreAdapterCommand extends GeoServerCommand<List<Strin
 
   private String storeName = null;
 
+  public void setParameters(List<String> parameters) {
+    this.parameters = parameters;
+  }
+
   @Override
   public void execute(final OperationParams params) throws Exception {
     final List<String> adapterList = computeResults(params);
 
-    JCommander.getConsole().println("Store " + storeName + " has these adapters:");
+    params.getConsole().println("Store " + storeName + " has these adapters:");
     for (final String adapterId : adapterList) {
-      JCommander.getConsole().println(adapterId);
+      params.getConsole().println(adapterId);
     }
   }
 

--- a/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/datastore/GeoServerListDatastoresCommand.java
+++ b/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/datastore/GeoServerListDatastoresCommand.java
@@ -13,7 +13,6 @@ import javax.ws.rs.core.Response.Status;
 import org.locationtech.geowave.cli.geoserver.GeoServerCommand;
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.OperationParams;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import net.sf.json.JSONArray;
@@ -27,7 +26,7 @@ public class GeoServerListDatastoresCommand extends GeoServerCommand<String> {
 
   @Override
   public void execute(final OperationParams params) throws Exception {
-    JCommander.getConsole().println(computeResults(params));
+    params.getConsole().println(computeResults(params));
   }
 
   @Override

--- a/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/datastore/GeoServerRemoveDatastoreCommand.java
+++ b/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/datastore/GeoServerRemoveDatastoreCommand.java
@@ -15,7 +15,6 @@ import javax.ws.rs.core.Response.Status;
 import org.locationtech.geowave.cli.geoserver.GeoServerRemoveCommand;
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.OperationParams;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
@@ -27,13 +26,17 @@ public class GeoServerRemoveDatastoreCommand extends GeoServerRemoveCommand<Stri
   private String workspace;
 
   @Parameter(description = "<datastore name>")
-  private final List<String> parameters = new ArrayList<>();
+  private List<String> parameters = new ArrayList<>();
 
   private String datastoreName = null;
 
   @Override
   public void execute(final OperationParams params) throws Exception {
-    JCommander.getConsole().println(computeResults(params));
+    params.getConsole().println(computeResults(params));
+  }
+
+  public void setParameters(final List<String> parameters) {
+    this.parameters = parameters;
   }
 
   @Override

--- a/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/featurelayer/GeoServerAddFeatureLayerCommand.java
+++ b/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/featurelayer/GeoServerAddFeatureLayerCommand.java
@@ -15,7 +15,6 @@ import javax.ws.rs.core.Response.Status;
 import org.locationtech.geowave.cli.geoserver.GeoServerCommand;
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.OperationParams;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
@@ -37,7 +36,15 @@ public class GeoServerAddFeatureLayerCommand extends GeoServerCommand<String> {
 
   @Override
   public void execute(final OperationParams params) throws Exception {
-    JCommander.getConsole().println(computeResults(params));
+    params.getConsole().println(computeResults(params));
+  }
+
+  public void setDatastore(final String datastore) {
+    this.datastore = datastore;
+  }
+
+  public void setParameters(final List<String> parameters) {
+    this.parameters = parameters;
   }
 
   @Override

--- a/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/featurelayer/GeoServerGetFeatureLayerCommand.java
+++ b/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/featurelayer/GeoServerGetFeatureLayerCommand.java
@@ -15,7 +15,6 @@ import javax.ws.rs.core.Response.Status;
 import org.locationtech.geowave.cli.geoserver.GeoServerCommand;
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.OperationParams;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
@@ -31,7 +30,11 @@ public class GeoServerGetFeatureLayerCommand extends GeoServerCommand<String> {
 
   @Override
   public void execute(final OperationParams params) throws Exception {
-    JCommander.getConsole().println(computeResults(params));
+    params.getConsole().println(computeResults(params));
+  }
+
+  public void setParameters(List<String> parameters) {
+    this.parameters = parameters;
   }
 
   @Override

--- a/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/featurelayer/GeoServerListFeatureLayersCommand.java
+++ b/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/featurelayer/GeoServerListFeatureLayersCommand.java
@@ -13,7 +13,6 @@ import javax.ws.rs.core.Response.Status;
 import org.locationtech.geowave.cli.geoserver.GeoServerCommand;
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.OperationParams;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import net.sf.json.JSONObject;
@@ -24,6 +23,10 @@ public class GeoServerListFeatureLayersCommand extends GeoServerCommand<String> 
   @Parameter(names = {"-ws", "--workspace"}, required = false, description = "Workspace Name")
   private String workspace = null;
 
+  public void setWorkspace(final String workspace) {
+    this.workspace = workspace;
+  }
+
   @Parameter(names = {"-ds", "--datastore"}, required = false, description = "Datastore Name")
   private String datastore = null;
 
@@ -33,9 +36,17 @@ public class GeoServerListFeatureLayersCommand extends GeoServerCommand<String> 
       description = "Show only GeoWave feature layers (default: false)")
   private Boolean geowaveOnly = false;
 
+  public void setGeowaveOnly(final Boolean geowaveOnly) {
+    this.geowaveOnly = geowaveOnly;
+  }
+
   @Override
   public void execute(final OperationParams params) throws Exception {
-    JCommander.getConsole().println(computeResults(params));
+    params.getConsole().println(computeResults(params));
+  }
+
+  public void setDatastore(final String datastore) {
+    this.datastore = datastore;
   }
 
   @Override

--- a/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/featurelayer/GeoServerRemoveFeatureLayerCommand.java
+++ b/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/featurelayer/GeoServerRemoveFeatureLayerCommand.java
@@ -15,7 +15,6 @@ import javax.ws.rs.core.Response.Status;
 import org.locationtech.geowave.cli.geoserver.GeoServerRemoveCommand;
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.OperationParams;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
@@ -31,7 +30,11 @@ public class GeoServerRemoveFeatureLayerCommand extends GeoServerRemoveCommand<S
 
   @Override
   public void execute(final OperationParams params) throws Exception {
-    JCommander.getConsole().println(computeResults(params));
+    params.getConsole().println(computeResults(params));
+  }
+
+  public void setParameters(final List<String> parameters) {
+    this.parameters = parameters;
   }
 
   @Override

--- a/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/layer/GeoServerAddLayerCommand.java
+++ b/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/layer/GeoServerAddLayerCommand.java
@@ -18,7 +18,6 @@ import org.locationtech.geowave.cli.geoserver.GeoServerCommand;
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.OperationParams;
 import com.beust.jcommander.IStringConverter;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
@@ -49,11 +48,23 @@ public class GeoServerAddLayerCommand extends GeoServerCommand<String> {
   @Parameter(description = "<GeoWave store name>")
   private List<String> parameters = new ArrayList<>();
 
+  public void setAddOption(final AddOption addOption) {
+    this.addOption = addOption;
+  }
+
+  public void setStyle(final String style) {
+    this.style = style;
+  }
+
+  public void setParameters(final List<String> parameters) {
+    this.parameters = parameters;
+  }
+
   private String gwStore = null;
 
   @Override
   public void execute(final OperationParams params) throws Exception {
-    JCommander.getConsole().println(computeResults(params));
+    params.getConsole().println(computeResults(params));
   }
 
   public static class AddOptionConverter implements IStringConverter<AddOption> {

--- a/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/style/GeoServerAddStyleCommand.java
+++ b/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/style/GeoServerAddStyleCommand.java
@@ -17,7 +17,6 @@ import javax.ws.rs.core.Response.Status;
 import org.locationtech.geowave.cli.geoserver.GeoServerCommand;
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.OperationParams;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
@@ -29,13 +28,21 @@ public class GeoServerAddStyleCommand extends GeoServerCommand<String> {
   private String stylesld = null;
 
   @Parameter(description = "<GeoWave style name>")
-  private List<String> parameters = new ArrayList<String>();
+  private List<String> parameters = new ArrayList<>();
 
   private String gwStyle = null;
 
+  public void setStylesld(final String stylesld) {
+    this.stylesld = stylesld;
+  }
+
+  public void setParameters(final List<String> parameters) {
+    this.parameters = parameters;
+  }
+
   @Override
   public void execute(final OperationParams params) throws Exception {
-    JCommander.getConsole().println(computeResults(params));
+    params.getConsole().println(computeResults(params));
   }
 
   @Override

--- a/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/style/GeoServerGetStyleCommand.java
+++ b/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/style/GeoServerGetStyleCommand.java
@@ -17,7 +17,6 @@ import org.apache.commons.io.IOUtils;
 import org.locationtech.geowave.cli.geoserver.GeoServerCommand;
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.OperationParams;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
@@ -30,9 +29,13 @@ public class GeoServerGetStyleCommand extends GeoServerCommand<String> {
 
   private String style = null;
 
+  public void setParameters(final List<String> parameters) {
+    this.parameters = parameters;
+  }
+
   @Override
   public void execute(final OperationParams params) throws Exception {
-    JCommander.getConsole().println(computeResults(params));
+    params.getConsole().println(computeResults(params));
   }
 
   @Override

--- a/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/style/GeoServerListStylesCommand.java
+++ b/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/style/GeoServerListStylesCommand.java
@@ -13,7 +13,6 @@ import javax.ws.rs.core.Response.Status;
 import org.locationtech.geowave.cli.geoserver.GeoServerCommand;
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.OperationParams;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameters;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
@@ -24,7 +23,7 @@ public class GeoServerListStylesCommand extends GeoServerCommand<String> {
 
   @Override
   public void execute(final OperationParams params) throws Exception {
-    JCommander.getConsole().println(computeResults(params));
+    params.getConsole().println(computeResults(params));
   }
 
   @Override

--- a/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/style/GeoServerRemoveStyleCommand.java
+++ b/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/style/GeoServerRemoveStyleCommand.java
@@ -15,7 +15,6 @@ import javax.ws.rs.core.Response.Status;
 import org.locationtech.geowave.cli.geoserver.GeoServerRemoveCommand;
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.OperationParams;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
@@ -28,9 +27,13 @@ public class GeoServerRemoveStyleCommand extends GeoServerRemoveCommand<String> 
 
   private String styleName = null;
 
+  public void setParameters(final List<String> parameters) {
+    this.parameters = parameters;
+  }
+
   @Override
   public void execute(final OperationParams params) throws Exception {
-    JCommander.getConsole().println(computeResults(params));
+    params.getConsole().println(computeResults(params));
   }
 
   @Override

--- a/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/style/GeoServerSetLayerStyleCommand.java
+++ b/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/style/GeoServerSetLayerStyleCommand.java
@@ -17,7 +17,6 @@ import org.apache.commons.io.IOUtils;
 import org.locationtech.geowave.cli.geoserver.GeoServerCommand;
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.OperationParams;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
@@ -41,7 +40,15 @@ public class GeoServerSetLayerStyleCommand extends GeoServerCommand<String> {
 
   @Override
   public void execute(final OperationParams params) throws Exception {
-    JCommander.getConsole().println(computeResults(params));
+    params.getConsole().println(computeResults(params));
+  }
+
+  public void setStyleName(final String styleName) {
+    this.styleName = styleName;
+  }
+
+  public void setParameters(final List<String> parameters) {
+    this.parameters = parameters;
   }
 
   @Override

--- a/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/workspace/GeoServerAddWorkspaceCommand.java
+++ b/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/workspace/GeoServerAddWorkspaceCommand.java
@@ -15,7 +15,6 @@ import javax.ws.rs.core.Response.Status;
 import org.locationtech.geowave.cli.geoserver.GeoServerCommand;
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.OperationParams;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
@@ -28,9 +27,13 @@ public class GeoServerAddWorkspaceCommand extends GeoServerCommand<String> {
 
   private String wsName = null;
 
+  public void setParameters(final List<String> parameters) {
+    this.parameters = parameters;
+  }
+
   @Override
   public void execute(final OperationParams params) throws Exception {
-    JCommander.getConsole().println(computeResults(params));
+    params.getConsole().println(computeResults(params));
   }
 
   @Override

--- a/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/workspace/GeoServerListWorkspacesCommand.java
+++ b/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/workspace/GeoServerListWorkspacesCommand.java
@@ -15,7 +15,6 @@ import javax.ws.rs.core.Response.Status;
 import org.locationtech.geowave.cli.geoserver.GeoServerCommand;
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.OperationParams;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameters;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
@@ -27,7 +26,7 @@ public class GeoServerListWorkspacesCommand extends GeoServerCommand<List<String
   @Override
   public void execute(final OperationParams params) throws Exception {
     for (final String string : computeResults(params)) {
-      JCommander.getConsole().println(string);
+      params.getConsole().println(string);
     }
   }
 

--- a/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/workspace/GeoServerRemoveWorkspaceCommand.java
+++ b/extensions/cli/geoserver/src/main/java/org/locationtech/geowave/cli/geoserver/workspace/GeoServerRemoveWorkspaceCommand.java
@@ -15,7 +15,6 @@ import javax.ws.rs.core.Response.Status;
 import org.locationtech.geowave.cli.geoserver.GeoServerRemoveCommand;
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.OperationParams;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
@@ -30,7 +29,11 @@ public class GeoServerRemoveWorkspaceCommand extends GeoServerRemoveCommand<Stri
 
   @Override
   public void execute(final OperationParams params) throws Exception {
-    JCommander.getConsole().println(computeResults(params));
+    params.getConsole().println(computeResults(params));
+  }
+
+  public void setParameters(final List<String> parameters) {
+    this.parameters = parameters;
   }
 
   @Override

--- a/extensions/cli/geoserver/src/test/java/org/locationtech/geowave/cli/geoserver/GeoServerRestClientTest.java
+++ b/extensions/cli/geoserver/src/test/java/org/locationtech/geowave/cli/geoserver/GeoServerRestClientTest.java
@@ -18,6 +18,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.internal.Console;
 
 public class GeoServerRestClientTest {
   WebTarget webTarget;
@@ -45,8 +47,9 @@ public class GeoServerRestClientTest {
   @Before
   public void prepare() {
     webTarget = mockedWebTarget();
-    config = new GeoServerConfig();
-    client = GeoServerRestClient.getInstance(config);
+    final Console console = new JCommander().getConsole();
+    config = new GeoServerConfig(console);
+    client = GeoServerRestClient.getInstance(config, console);
     client.setWebTarget(webTarget);
   }
 

--- a/extensions/cli/landsat8/src/main/java/org/locationtech/geowave/format/landsat8/IngestRunner.java
+++ b/extensions/cli/landsat8/src/main/java/org/locationtech/geowave/format/landsat8/IngestRunner.java
@@ -58,7 +58,7 @@ public class IngestRunner extends RasterIngestRunner {
         && !vectorOverrideOptions.getVectorStore().trim().isEmpty()) {
       final String vectorStoreName = vectorOverrideOptions.getVectorStore();
       final StoreLoader vectorStoreLoader = new StoreLoader(vectorStoreName);
-      if (!vectorStoreLoader.loadFromConfig(configFile)) {
+      if (!vectorStoreLoader.loadFromConfig(configFile, params.getConsole())) {
         throw new ParameterException(
             "Cannot find vector store name: " + vectorStoreLoader.getStoreName());
       }

--- a/extensions/cli/landsat8/src/main/java/org/locationtech/geowave/format/landsat8/RasterIngestRunner.java
+++ b/extensions/cli/landsat8/src/main/java/org/locationtech/geowave/format/landsat8/RasterIngestRunner.java
@@ -103,7 +103,7 @@ public class RasterIngestRunner extends DownloadRunner {
 
     // Attempt to load input store.
     final StoreLoader inputStoreLoader = new StoreLoader(inputStoreName);
-    if (!inputStoreLoader.loadFromConfig(configFile)) {
+    if (!inputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
     }
     dataStorePluginOptions = inputStoreLoader.getDataStorePlugin();

--- a/extensions/cli/landsat8/src/main/java/org/locationtech/geowave/format/landsat8/VectorIngestRunner.java
+++ b/extensions/cli/landsat8/src/main/java/org/locationtech/geowave/format/landsat8/VectorIngestRunner.java
@@ -59,7 +59,7 @@ public class VectorIngestRunner extends AnalyzeRunner {
 
       // Attempt to load input store.
       final StoreLoader inputStoreLoader = new StoreLoader(inputStoreName);
-      if (!inputStoreLoader.loadFromConfig(configFile)) {
+      if (!inputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
         throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
       }
       final DataStorePluginOptions storeOptions = inputStoreLoader.getDataStorePlugin();

--- a/extensions/cli/landsat8/src/test/java/org/locationtech/geowave/format/landsat8/IngestRunnerTest.java
+++ b/extensions/cli/landsat8/src/test/java/org/locationtech/geowave/format/landsat8/IngestRunnerTest.java
@@ -31,6 +31,7 @@ import org.locationtech.geowave.core.store.cli.store.StoreLoader;
 import org.locationtech.geowave.core.store.index.IndexPluginOptions.PartitionStrategy;
 import org.locationtech.geowave.core.store.index.IndexStore;
 import org.locationtech.geowave.core.store.memory.MemoryStoreFactoryFamily;
+import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
 import it.geosolutions.jaiext.JAIExt;
 
@@ -111,23 +112,23 @@ public class IngestRunnerTest {
     final File configFile = (File) params.getContext().get(ConfigOptions.PROPERTIES_FILE_CONTEXT);
 
     final StoreLoader inputStoreLoader = new StoreLoader(storeName);
-    if (!inputStoreLoader.loadFromConfig(configFile)) {
+    if (!inputStoreLoader.loadFromConfig(configFile, new JCommander().getConsole())) {
       throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
     }
     return inputStoreLoader.getDataStorePlugin();
   }
 
   private void createIndices(final OperationParams params, final String storeName) {
-    IndexStore indexStore = getStorePluginOptions(params, storeName).createIndexStore();
+    final IndexStore indexStore = getStorePluginOptions(params, storeName).createIndexStore();
     // Create the spatial index
-    SpatialIndexBuilder builder = new SpatialIndexBuilder();
+    final SpatialIndexBuilder builder = new SpatialIndexBuilder();
     builder.setName("spatialindex");
     builder.setNumPartitions(1);
     builder.setIncludeTimeInCommonIndexModel(false);
     indexStore.addIndex(builder.createIndex());
 
     // Create the spatial temporal index
-    SpatialTemporalIndexBuilder st_builder = new SpatialTemporalIndexBuilder();
+    final SpatialTemporalIndexBuilder st_builder = new SpatialTemporalIndexBuilder();
     st_builder.setName("spatempindex");
     st_builder.setBias(Bias.BALANCED);
     st_builder.setMaxDuplicates(-1);

--- a/extensions/cli/landsat8/src/test/java/org/locationtech/geowave/format/landsat8/RasterIngestRunnerTest.java
+++ b/extensions/cli/landsat8/src/test/java/org/locationtech/geowave/format/landsat8/RasterIngestRunnerTest.java
@@ -27,6 +27,7 @@ import org.locationtech.geowave.core.store.cli.store.DataStorePluginOptions;
 import org.locationtech.geowave.core.store.cli.store.StoreLoader;
 import org.locationtech.geowave.core.store.index.IndexStore;
 import org.locationtech.geowave.core.store.memory.MemoryStoreFactoryFamily;
+import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
 import it.geosolutions.jaiext.JAIExt;
 
@@ -96,16 +97,16 @@ public class RasterIngestRunnerTest {
     final File configFile = (File) params.getContext().get(ConfigOptions.PROPERTIES_FILE_CONTEXT);
 
     final StoreLoader inputStoreLoader = new StoreLoader("memorystore");
-    if (!inputStoreLoader.loadFromConfig(configFile)) {
+    if (!inputStoreLoader.loadFromConfig(configFile, new JCommander().getConsole())) {
       throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
     }
     return inputStoreLoader.getDataStorePlugin();
   }
 
   private void createIndices(final OperationParams params) {
-    IndexStore indexStore = getStorePluginOptions(params).createIndexStore();
+    final IndexStore indexStore = getStorePluginOptions(params).createIndexStore();
     // Create the spatial index
-    SpatialIndexBuilder builder = new SpatialIndexBuilder();
+    final SpatialIndexBuilder builder = new SpatialIndexBuilder();
     builder.setName("spatialindex");
     builder.setNumPartitions(1);
     builder.setIncludeTimeInCommonIndexModel(false);

--- a/extensions/cli/landsat8/src/test/java/org/locationtech/geowave/format/landsat8/VectorIngestRunnerTest.java
+++ b/extensions/cli/landsat8/src/test/java/org/locationtech/geowave/format/landsat8/VectorIngestRunnerTest.java
@@ -26,6 +26,7 @@ import org.locationtech.geowave.core.store.cli.store.DataStorePluginOptions;
 import org.locationtech.geowave.core.store.cli.store.StoreLoader;
 import org.locationtech.geowave.core.store.index.IndexStore;
 import org.locationtech.geowave.core.store.memory.MemoryStoreFactoryFamily;
+import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
 import it.geosolutions.jaiext.JAIExt;
 
@@ -82,16 +83,16 @@ public class VectorIngestRunnerTest {
     final File configFile = (File) params.getContext().get(ConfigOptions.PROPERTIES_FILE_CONTEXT);
 
     final StoreLoader inputStoreLoader = new StoreLoader("memorystore");
-    if (!inputStoreLoader.loadFromConfig(configFile)) {
+    if (!inputStoreLoader.loadFromConfig(configFile, new JCommander().getConsole())) {
       throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
     }
     return inputStoreLoader.getDataStorePlugin();
   }
 
   private void createIndices(final OperationParams params) {
-    IndexStore indexStore = getStorePluginOptions(params).createIndexStore();
+    final IndexStore indexStore = getStorePluginOptions(params).createIndexStore();
     // Create the spatial index
-    SpatialIndexBuilder builder = new SpatialIndexBuilder();
+    final SpatialIndexBuilder builder = new SpatialIndexBuilder();
     builder.setName("spatialindex");
     builder.setNumPartitions(1);
     builder.setIncludeTimeInCommonIndexModel(false);

--- a/extensions/cli/osm/src/main/java/org/locationtech/geowave/cli/osm/operations/IngestOSMToGeoWaveCommand.java
+++ b/extensions/cli/osm/src/main/java/org/locationtech/geowave/cli/osm/operations/IngestOSMToGeoWaveCommand.java
@@ -53,7 +53,7 @@ public class IngestOSMToGeoWaveCommand extends DefaultOperation implements Comma
     }
 
     for (final String string : computeResults(params)) {
-      JCommander.getConsole().println(string);
+      params.getConsole().println(string);
     }
   }
 
@@ -123,7 +123,7 @@ public class IngestOSMToGeoWaveCommand extends DefaultOperation implements Comma
     final String hdfsHostPort = ConfigHDFSCommand.getHdfsUrl(configProperties);
 
     final StoreLoader inputStoreLoader = new StoreLoader(inputStoreName);
-    if (!inputStoreLoader.loadFromConfig(configFile)) {
+    if (!inputStoreLoader.loadFromConfig(configFile, new JCommander().getConsole())) {
       throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
     }
     inputStoreOptions = inputStoreLoader.getDataStorePlugin();

--- a/extensions/cli/sentinel2/src/main/java/org/locationtech/geowave/format/sentinel2/IngestRunner.java
+++ b/extensions/cli/sentinel2/src/main/java/org/locationtech/geowave/format/sentinel2/IngestRunner.java
@@ -61,7 +61,7 @@ public class IngestRunner extends RasterIngestRunner {
       final String vectorStoreName = vectorOverrideOptions.getVectorStore();
 
       final StoreLoader vectorStoreLoader = new StoreLoader(vectorStoreName);
-      if (!vectorStoreLoader.loadFromConfig(configFile)) {
+      if (!vectorStoreLoader.loadFromConfig(configFile, params.getConsole())) {
         throw new ParameterException(
             "Cannot find vector store name: " + vectorStoreLoader.getStoreName());
       }

--- a/extensions/cli/sentinel2/src/main/java/org/locationtech/geowave/format/sentinel2/RasterIngestRunner.java
+++ b/extensions/cli/sentinel2/src/main/java/org/locationtech/geowave/format/sentinel2/RasterIngestRunner.java
@@ -112,7 +112,7 @@ public class RasterIngestRunner extends DownloadRunner {
 
     // Attempt to load input store.
     final StoreLoader inputStoreLoader = new StoreLoader(inputStoreName);
-    if (!inputStoreLoader.loadFromConfig(configFile)) {
+    if (!inputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
     }
 

--- a/extensions/cli/sentinel2/src/main/java/org/locationtech/geowave/format/sentinel2/Sentinel2Section.java
+++ b/extensions/cli/sentinel2/src/main/java/org/locationtech/geowave/format/sentinel2/Sentinel2Section.java
@@ -10,7 +10,7 @@ package org.locationtech.geowave.format.sentinel2;
 
 import org.locationtech.geowave.core.cli.annotations.GeowaveOperation;
 import org.locationtech.geowave.core.cli.api.DefaultOperation;
-import org.locationtech.geowave.core.cli.operations.GeowaveTopLevelSection;
+import org.locationtech.geowave.core.cli.operations.GeoWaveTopLevelSection;
 import org.locationtech.geowave.core.cli.operations.util.UtilSection;
 import com.beust.jcommander.Parameters;
 

--- a/extensions/cli/sentinel2/src/main/java/org/locationtech/geowave/format/sentinel2/VectorIngestRunner.java
+++ b/extensions/cli/sentinel2/src/main/java/org/locationtech/geowave/format/sentinel2/VectorIngestRunner.java
@@ -66,7 +66,7 @@ public class VectorIngestRunner extends AnalyzeRunner {
 
       // Attempt to load input store.
       final StoreLoader inputStoreLoader = new StoreLoader(inputStoreName);
-      if (!inputStoreLoader.loadFromConfig(configFile)) {
+      if (!inputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
         throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
       }
 

--- a/extensions/cli/sentinel2/src/test/java/org/locationtech/geowave/format/sentinel2/IngestRunnerTest.java
+++ b/extensions/cli/sentinel2/src/test/java/org/locationtech/geowave/format/sentinel2/IngestRunnerTest.java
@@ -149,23 +149,23 @@ public class IngestRunnerTest {
     final File configFile = (File) params.getContext().get(ConfigOptions.PROPERTIES_FILE_CONTEXT);
 
     final StoreLoader inputStoreLoader = new StoreLoader(storeName);
-    if (!inputStoreLoader.loadFromConfig(configFile)) {
+    if (!inputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
     }
     return inputStoreLoader.getDataStorePlugin();
   }
 
   private void createIndices(final OperationParams params, final String storeName) {
-    IndexStore indexStore = getStorePluginOptions(params, storeName).createIndexStore();
+    final IndexStore indexStore = getStorePluginOptions(params, storeName).createIndexStore();
     // Create the spatial index
-    SpatialIndexBuilder builder = new SpatialIndexBuilder();
+    final SpatialIndexBuilder builder = new SpatialIndexBuilder();
     builder.setName("spatialindex");
     builder.setNumPartitions(1);
     builder.setIncludeTimeInCommonIndexModel(false);
     indexStore.addIndex(builder.createIndex());
 
     // Create the spatial temporal index
-    SpatialTemporalIndexBuilder st_builder = new SpatialTemporalIndexBuilder();
+    final SpatialTemporalIndexBuilder st_builder = new SpatialTemporalIndexBuilder();
     st_builder.setName("spatempindex");
     st_builder.setBias(Bias.BALANCED);
     st_builder.setMaxDuplicates(-1);

--- a/extensions/cli/sentinel2/src/test/java/org/locationtech/geowave/format/sentinel2/RasterIngestRunnerTest.java
+++ b/extensions/cli/sentinel2/src/test/java/org/locationtech/geowave/format/sentinel2/RasterIngestRunnerTest.java
@@ -134,7 +134,7 @@ public class RasterIngestRunnerTest {
     final File configFile = (File) params.getContext().get(ConfigOptions.PROPERTIES_FILE_CONTEXT);
 
     final StoreLoader inputStoreLoader = new StoreLoader("memorystore");
-    if (!inputStoreLoader.loadFromConfig(configFile)) {
+    if (!inputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
     }
 
@@ -142,9 +142,9 @@ public class RasterIngestRunnerTest {
   }
 
   private void createIndices(final OperationParams params) {
-    IndexStore indexStore = getStorePluginOptions(params).createIndexStore();
+    final IndexStore indexStore = getStorePluginOptions(params).createIndexStore();
     // Create the spatial index
-    SpatialIndexBuilder builder = new SpatialIndexBuilder();
+    final SpatialIndexBuilder builder = new SpatialIndexBuilder();
     builder.setName("spatialindex");
     builder.setNumPartitions(1);
     builder.setIncludeTimeInCommonIndexModel(false);

--- a/extensions/cli/sentinel2/src/test/java/org/locationtech/geowave/format/sentinel2/VectorIngestRunnerTest.java
+++ b/extensions/cli/sentinel2/src/test/java/org/locationtech/geowave/format/sentinel2/VectorIngestRunnerTest.java
@@ -100,7 +100,7 @@ public class VectorIngestRunnerTest {
     final File configFile = (File) params.getContext().get(ConfigOptions.PROPERTIES_FILE_CONTEXT);
 
     final StoreLoader inputStoreLoader = new StoreLoader("memorystore");
-    if (!inputStoreLoader.loadFromConfig(configFile)) {
+    if (!inputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
     }
 
@@ -108,16 +108,16 @@ public class VectorIngestRunnerTest {
   }
 
   private void createIndices(final OperationParams params) {
-    IndexStore indexStore = getStorePluginOptions(params).createIndexStore();
+    final IndexStore indexStore = getStorePluginOptions(params).createIndexStore();
     // Create the spatial index
-    SpatialIndexBuilder builder = new SpatialIndexBuilder();
+    final SpatialIndexBuilder builder = new SpatialIndexBuilder();
     builder.setName("spatialindex");
     builder.setNumPartitions(1);
     builder.setIncludeTimeInCommonIndexModel(false);
     indexStore.addIndex(builder.createIndex());
 
     // Create the spatial temporal index
-    SpatialTemporalIndexBuilder st_builder = new SpatialTemporalIndexBuilder();
+    final SpatialTemporalIndexBuilder st_builder = new SpatialTemporalIndexBuilder();
     st_builder.setName("spatempindex");
     st_builder.setBias(Bias.BALANCED);
     st_builder.setMaxDuplicates(-1);

--- a/extensions/datastores/accumulo/src/main/java/org/locationtech/geowave/datastore/accumulo/cli/AbstractSplitsCommand.java
+++ b/extensions/datastores/accumulo/src/main/java/org/locationtech/geowave/datastore/accumulo/cli/AbstractSplitsCommand.java
@@ -45,7 +45,7 @@ public abstract class AbstractSplitsCommand extends DefaultOperation {
     final File configFile = getGeoWaveConfigFile(params);
 
     final StoreLoader inputStoreLoader = new StoreLoader(inputStoreName);
-    if (!inputStoreLoader.loadFromConfig(configFile)) {
+    if (!inputStoreLoader.loadFromConfig(configFile, params.getConsole())) {
       throw new ParameterException("Cannot find store name: " + inputStoreLoader.getStoreName());
     }
     inputStoreOptions = inputStoreLoader.getDataStorePlugin();

--- a/extensions/datastores/filesystem/src/main/java/org/locationtech/geowave/datastore/filesystem/cli/ListFormatsCommand.java
+++ b/extensions/datastores/filesystem/src/main/java/org/locationtech/geowave/datastore/filesystem/cli/ListFormatsCommand.java
@@ -14,7 +14,6 @@ import org.locationtech.geowave.core.cli.api.OperationParams;
 import org.locationtech.geowave.core.cli.api.ServiceEnabledCommand;
 import org.locationtech.geowave.datastore.filesystem.FileSystemDataFormatterRegistry;
 import org.locationtech.geowave.datastore.filesystem.FileSystemDataFormatterSpi;
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameters;
 
 @GeowaveOperation(name = "listformats", parentOperation = FileSystemSection.class)
@@ -24,7 +23,7 @@ public class ListFormatsCommand extends ServiceEnabledCommand<String> {
 
   @Override
   public void execute(final OperationParams params) {
-    JCommander.getConsole().println(computeResults(params));
+    params.getConsole().println(computeResults(params));
   }
 
   @Override

--- a/extensions/datastores/filesystem/src/main/java/org/locationtech/geowave/datastore/filesystem/config/FileSystemOptions.java
+++ b/extensions/datastores/filesystem/src/main/java/org/locationtech/geowave/datastore/filesystem/config/FileSystemOptions.java
@@ -20,6 +20,7 @@ import org.locationtech.geowave.datastore.filesystem.util.GeoWaveBinaryDataForma
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.ParametersDelegate;
+import com.beust.jcommander.internal.Console;
 
 public class FileSystemOptions extends StoreFactoryOptions {
   @Parameter(
@@ -66,17 +67,18 @@ public class FileSystemOptions extends StoreFactoryOptions {
   }
 
   @Override
-  public void validatePluginOptions() throws ParameterException {
+  public void validatePluginOptions(final Console console) throws ParameterException {
     // Set the directory to be absolute
     dir = Paths.get(dir).toAbsolutePath().toString();
-    super.validatePluginOptions();
+    super.validatePluginOptions(console);
   }
 
   @Override
-  public void validatePluginOptions(final Properties properties) throws ParameterException {
+  public void validatePluginOptions(final Properties properties, final Console console)
+      throws ParameterException {
     // Set the directory to be absolute
     dir = Paths.get(dir).toAbsolutePath().toString();
-    super.validatePluginOptions(properties);
+    super.validatePluginOptions(properties, console);
   }
 
   public FileSystemOptions() {

--- a/extensions/datastores/rocksdb/src/main/java/org/locationtech/geowave/datastore/rocksdb/config/RocksDBOptions.java
+++ b/extensions/datastores/rocksdb/src/main/java/org/locationtech/geowave/datastore/rocksdb/config/RocksDBOptions.java
@@ -19,6 +19,7 @@ import org.locationtech.geowave.datastore.rocksdb.util.RocksDBUtils;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.ParametersDelegate;
+import com.beust.jcommander.internal.Console;
 
 public class RocksDBOptions extends StoreFactoryOptions {
   @Parameter(
@@ -60,17 +61,18 @@ public class RocksDBOptions extends StoreFactoryOptions {
   };
 
   @Override
-  public void validatePluginOptions() throws ParameterException {
+  public void validatePluginOptions(final Console console) throws ParameterException {
     // Set the directory to be absolute
     dir = new File(dir).getAbsolutePath();
-    super.validatePluginOptions();
+    super.validatePluginOptions(console);
   }
 
   @Override
-  public void validatePluginOptions(final Properties properties) throws ParameterException {
+  public void validatePluginOptions(final Properties properties, final Console console)
+      throws ParameterException {
     // Set the directory to be absolute
     dir = new File(dir).getAbsolutePath();
-    super.validatePluginOptions(properties);
+    super.validatePluginOptions(properties, console);
   }
 
   public RocksDBOptions() {

--- a/extensions/datastores/rocksdb/src/main/java/org/locationtech/geowave/datastore/rocksdb/util/RocksDBDataIndexTable.java
+++ b/extensions/datastores/rocksdb/src/main/java/org/locationtech/geowave/datastore/rocksdb/util/RocksDBDataIndexTable.java
@@ -54,10 +54,14 @@ public class RocksDBDataIndexTable extends AbstractRocksDBTable {
   }
 
   public CloseableIterator<GeoWaveRow> dataIndexIterator(final byte[][] dataIds) {
+    if (dataIds == null || dataIds.length == 0) {
+      return new CloseableIterator.Empty<>();
+    }
     final RocksDB readDb = getReadDb();
     if (readDb == null) {
       return new CloseableIterator.Empty<>();
     }
+
     try {
       final List<byte[]> dataIdsList = Arrays.asList(dataIds);
       final Map<byte[], byte[]> dataIdxResults = readDb.multiGet(dataIdsList);

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
 		<kafka.version>0.8.2.1</kafka.version>
 		<snappy.version>1.1.2.6</snappy.version>
 		<collections4.version>4.1</collections4.version>
-		<jcommander.version>1.48</jcommander.version>
+		<jcommander.version>1.78</jcommander.version>
 		<jackson.version>1.9.13</jackson.version>
 		<fasterxml.jackson.version>2.9.5</fasterxml.jackson.version>
 		<spring-security.version>4.2.7.RELEASE</spring-security.version>

--- a/services/grpc/server/src/main/java/org/locationtech/geowave/service/grpc/services/GeoWaveGrpcCoreIngestService.java
+++ b/services/grpc/server/src/main/java/org/locationtech/geowave/service/grpc/services/GeoWaveGrpcCoreIngestService.java
@@ -13,14 +13,14 @@ import java.util.Map;
 import org.locationtech.geowave.core.cli.api.OperationParams;
 import org.locationtech.geowave.core.cli.operations.config.options.ConfigOptions;
 import org.locationtech.geowave.core.cli.parser.ManualOperationParams;
-import org.locationtech.geowave.core.ingest.operations.KafkaToGeowaveCommand;
+import org.locationtech.geowave.core.ingest.operations.KafkaToGeoWaveCommand;
 import org.locationtech.geowave.core.ingest.operations.ListIngestPluginsCommand;
-import org.locationtech.geowave.core.ingest.operations.LocalToGeowaveCommand;
+import org.locationtech.geowave.core.ingest.operations.LocalToGeoWaveCommand;
 import org.locationtech.geowave.core.ingest.operations.LocalToHdfsCommand;
 import org.locationtech.geowave.core.ingest.operations.LocalToKafkaCommand;
-import org.locationtech.geowave.core.ingest.operations.LocalToMapReduceToGeowaveCommand;
-import org.locationtech.geowave.core.ingest.operations.MapReduceToGeowaveCommand;
-import org.locationtech.geowave.core.ingest.operations.SparkToGeowaveCommand;
+import org.locationtech.geowave.core.ingest.operations.LocalToMapReduceToGeoWaveCommand;
+import org.locationtech.geowave.core.ingest.operations.MapReduceToGeoWaveCommand;
+import org.locationtech.geowave.core.ingest.operations.SparkToGeoWaveCommand;
 import org.locationtech.geowave.service.grpc.GeoWaveGrpcServiceOptions;
 import org.locationtech.geowave.service.grpc.GeoWaveGrpcServiceSpi;
 import org.locationtech.geowave.service.grpc.protobuf.CoreIngestGrpc.CoreIngestImplBase;
@@ -71,10 +71,10 @@ public class GeoWaveGrpcCoreIngestService extends CoreIngestImplBase implements
   }
 
   @Override
-  public void sparkToGeowaveCommand(
-      final org.locationtech.geowave.service.grpc.protobuf.SparkToGeowaveCommandParametersProtos request,
+  public void sparkToGeoWaveCommand(
+      final org.locationtech.geowave.service.grpc.protobuf.SparkToGeoWaveCommandParametersProtos request,
       final StreamObserver<org.locationtech.geowave.service.grpc.protobuf.GeoWaveReturnTypesProtos.VoidResponseProtos> responseObserver) {
-    final SparkToGeowaveCommand cmd = new SparkToGeowaveCommand();
+    final SparkToGeoWaveCommand cmd = new SparkToGeoWaveCommand();
     final Map<FieldDescriptor, Object> m = request.getAllFields();
     GeoWaveGrpcServiceCommandUtil.setGrpcToCommandFields(m, cmd);
 
@@ -99,11 +99,11 @@ public class GeoWaveGrpcCoreIngestService extends CoreIngestImplBase implements
   }
 
   @Override
-  public void kafkaToGeowaveCommand(
-      final org.locationtech.geowave.service.grpc.protobuf.KafkaToGeowaveCommandParametersProtos request,
+  public void kafkaToGeoWaveCommand(
+      final org.locationtech.geowave.service.grpc.protobuf.KafkaToGeoWaveCommandParametersProtos request,
       final StreamObserver<org.locationtech.geowave.service.grpc.protobuf.GeoWaveReturnTypesProtos.VoidResponseProtos> responseObserver) {
 
-    final KafkaToGeowaveCommand cmd = new KafkaToGeowaveCommand();
+    final KafkaToGeoWaveCommand cmd = new KafkaToGeoWaveCommand();
     final Map<FieldDescriptor, Object> m = request.getAllFields();
     GeoWaveGrpcServiceCommandUtil.setGrpcToCommandFields(m, cmd);
 
@@ -181,10 +181,10 @@ public class GeoWaveGrpcCoreIngestService extends CoreIngestImplBase implements
   }
 
   @Override
-  public void localToMapReduceToGeowaveCommand(
-      final org.locationtech.geowave.service.grpc.protobuf.LocalToMapReduceToGeowaveCommandParametersProtos request,
+  public void localToMapReduceToGeoWaveCommand(
+      final org.locationtech.geowave.service.grpc.protobuf.LocalToMapReduceToGeoWaveCommandParametersProtos request,
       final StreamObserver<org.locationtech.geowave.service.grpc.protobuf.GeoWaveReturnTypesProtos.VoidResponseProtos> responseObserver) {
-    final LocalToMapReduceToGeowaveCommand cmd = new LocalToMapReduceToGeowaveCommand();
+    final LocalToMapReduceToGeoWaveCommand cmd = new LocalToMapReduceToGeoWaveCommand();
     final Map<FieldDescriptor, Object> m = request.getAllFields();
     GeoWaveGrpcServiceCommandUtil.setGrpcToCommandFields(m, cmd);
 
@@ -207,11 +207,11 @@ public class GeoWaveGrpcCoreIngestService extends CoreIngestImplBase implements
   }
 
   @Override
-  public void localToGeowaveCommand(
-      final org.locationtech.geowave.service.grpc.protobuf.LocalToGeowaveCommandParametersProtos request,
+  public void localToGeoWaveCommand(
+      final org.locationtech.geowave.service.grpc.protobuf.LocalToGeoWaveCommandParametersProtos request,
       final StreamObserver<org.locationtech.geowave.service.grpc.protobuf.GeoWaveReturnTypesProtos.VoidResponseProtos> responseObserver) {
 
-    final LocalToGeowaveCommand cmd = new LocalToGeowaveCommand();
+    final LocalToGeoWaveCommand cmd = new LocalToGeoWaveCommand();
     final Map<FieldDescriptor, Object> m = request.getAllFields();
     GeoWaveGrpcServiceCommandUtil.setGrpcToCommandFields(m, cmd);
 
@@ -234,11 +234,11 @@ public class GeoWaveGrpcCoreIngestService extends CoreIngestImplBase implements
   }
 
   @Override
-  public void mapReduceToGeowaveCommand(
-      final org.locationtech.geowave.service.grpc.protobuf.MapReduceToGeowaveCommandParametersProtos request,
+  public void mapReduceToGeoWaveCommand(
+      final org.locationtech.geowave.service.grpc.protobuf.MapReduceToGeoWaveCommandParametersProtos request,
       final StreamObserver<org.locationtech.geowave.service.grpc.protobuf.GeoWaveReturnTypesProtos.VoidResponseProtos> responseObserver) {
 
-    final MapReduceToGeowaveCommand cmd = new MapReduceToGeowaveCommand();
+    final MapReduceToGeoWaveCommand cmd = new MapReduceToGeoWaveCommand();
     final Map<FieldDescriptor, Object> m = request.getAllFields();
     GeoWaveGrpcServiceCommandUtil.setGrpcToCommandFields(m, cmd);
 

--- a/services/rest/src/main/java/org/locationtech/geowave/service/rest/operations/AddAccumuloStoreCommand.java
+++ b/services/rest/src/main/java/org/locationtech/geowave/service/rest/operations/AddAccumuloStoreCommand.java
@@ -90,7 +90,7 @@ public class AddAccumuloStoreCommand extends ServiceEnabledCommand<String> {
     }
 
     // Write properties file
-    ConfigOptions.writeProperties(propFile, existingProps);
+    ConfigOptions.writeProperties(propFile, existingProps, params.getConsole());
 
     final StringBuilder builder = new StringBuilder();
     for (final Object key : existingProps.keySet()) {

--- a/services/rest/src/main/java/org/locationtech/geowave/service/rest/operations/AddBigTableStoreCommand.java
+++ b/services/rest/src/main/java/org/locationtech/geowave/service/rest/operations/AddBigTableStoreCommand.java
@@ -84,7 +84,7 @@ public class AddBigTableStoreCommand extends ServiceEnabledCommand<String> {
     }
 
     // Write properties file
-    ConfigOptions.writeProperties(propFile, existingProps);
+    ConfigOptions.writeProperties(propFile, existingProps, params.getConsole());
 
     final StringBuilder builder = new StringBuilder();
     for (final Object key : existingProps.keySet()) {

--- a/services/rest/src/main/java/org/locationtech/geowave/service/rest/operations/AddCassandraStoreCommand.java
+++ b/services/rest/src/main/java/org/locationtech/geowave/service/rest/operations/AddCassandraStoreCommand.java
@@ -83,7 +83,7 @@ public class AddCassandraStoreCommand extends ServiceEnabledCommand<String> {
     }
 
     // Write properties file
-    ConfigOptions.writeProperties(propFile, existingProps);
+    ConfigOptions.writeProperties(propFile, existingProps, params.getConsole());
 
     final StringBuilder builder = new StringBuilder();
     for (final Object key : existingProps.keySet()) {

--- a/services/rest/src/main/java/org/locationtech/geowave/service/rest/operations/AddDynamoDBStoreCommand.java
+++ b/services/rest/src/main/java/org/locationtech/geowave/service/rest/operations/AddDynamoDBStoreCommand.java
@@ -83,7 +83,7 @@ public class AddDynamoDBStoreCommand extends ServiceEnabledCommand<String> {
     }
 
     // Write properties file
-    ConfigOptions.writeProperties(propFile, existingProps);
+    ConfigOptions.writeProperties(propFile, existingProps, params.getConsole());
 
     final StringBuilder builder = new StringBuilder();
     for (final Object key : existingProps.keySet()) {

--- a/services/rest/src/main/java/org/locationtech/geowave/service/rest/operations/AddFileSystemStoreCommand.java
+++ b/services/rest/src/main/java/org/locationtech/geowave/service/rest/operations/AddFileSystemStoreCommand.java
@@ -82,7 +82,7 @@ public class AddFileSystemStoreCommand extends ServiceEnabledCommand<String> {
     }
 
     // Write properties file
-    ConfigOptions.writeProperties(propFile, existingProps);
+    ConfigOptions.writeProperties(propFile, existingProps, params.getConsole());
 
     final StringBuilder builder = new StringBuilder();
     for (final Object key : existingProps.keySet()) {

--- a/services/rest/src/main/java/org/locationtech/geowave/service/rest/operations/AddHBaseStoreCommand.java
+++ b/services/rest/src/main/java/org/locationtech/geowave/service/rest/operations/AddHBaseStoreCommand.java
@@ -83,7 +83,7 @@ public class AddHBaseStoreCommand extends ServiceEnabledCommand<String> {
     }
 
     // Write properties file
-    ConfigOptions.writeProperties(propFile, existingProps);
+    ConfigOptions.writeProperties(propFile, existingProps, params.getConsole());
 
     final StringBuilder builder = new StringBuilder();
     for (final Object key : existingProps.keySet()) {

--- a/services/rest/src/main/java/org/locationtech/geowave/service/rest/operations/AddKuduStoreCommand.java
+++ b/services/rest/src/main/java/org/locationtech/geowave/service/rest/operations/AddKuduStoreCommand.java
@@ -83,7 +83,7 @@ public class AddKuduStoreCommand extends ServiceEnabledCommand<String> {
     }
 
     // Write properties file
-    ConfigOptions.writeProperties(propFile, existingProps);
+    ConfigOptions.writeProperties(propFile, existingProps, params.getConsole());
 
     final StringBuilder builder = new StringBuilder();
     for (final Object key : existingProps.keySet()) {

--- a/services/rest/src/main/java/org/locationtech/geowave/service/rest/operations/AddRedisStoreCommand.java
+++ b/services/rest/src/main/java/org/locationtech/geowave/service/rest/operations/AddRedisStoreCommand.java
@@ -82,7 +82,7 @@ public class AddRedisStoreCommand extends ServiceEnabledCommand<String> {
     }
 
     // Write properties file
-    ConfigOptions.writeProperties(propFile, existingProps);
+    ConfigOptions.writeProperties(propFile, existingProps, params.getConsole());
 
     final StringBuilder builder = new StringBuilder();
     for (final Object key : existingProps.keySet()) {

--- a/services/rest/src/main/java/org/locationtech/geowave/service/rest/operations/AddRocksDBStoreCommand.java
+++ b/services/rest/src/main/java/org/locationtech/geowave/service/rest/operations/AddRocksDBStoreCommand.java
@@ -82,7 +82,7 @@ public class AddRocksDBStoreCommand extends ServiceEnabledCommand<String> {
     }
 
     // Write properties file
-    ConfigOptions.writeProperties(propFile, existingProps);
+    ConfigOptions.writeProperties(propFile, existingProps, params.getConsole());
 
     final StringBuilder builder = new StringBuilder();
     for (final Object key : existingProps.keySet()) {

--- a/test/src/main/java/org/locationtech/geowave/test/TestUtils.java
+++ b/test/src/main/java/org/locationtech/geowave/test/TestUtils.java
@@ -59,7 +59,7 @@ import org.locationtech.geowave.core.geotime.util.TWKBReader;
 import org.locationtech.geowave.core.geotime.util.TWKBWriter;
 import org.locationtech.geowave.core.geotime.util.TimeUtils;
 import org.locationtech.geowave.core.ingest.operations.ConfigAWSCommand;
-import org.locationtech.geowave.core.ingest.operations.LocalToGeowaveCommand;
+import org.locationtech.geowave.core.ingest.operations.LocalToGeoWaveCommand;
 import org.locationtech.geowave.core.ingest.operations.options.IngestFormatPluginOptions;
 import org.locationtech.geowave.core.ingest.spark.SparkCommandLineOptions;
 import org.locationtech.geowave.core.ingest.spark.SparkIngestDriver;
@@ -89,6 +89,7 @@ import org.opengis.referencing.operation.MathTransform;
 import org.opengis.referencing.operation.TransformException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -268,12 +269,12 @@ public class TestUtils {
     addStore.setPluginOptions(dataStore);
     addStore.execute(params);
 
-    IndexStore indexStore = dataStore.createIndexStore();
+    final IndexStore indexStore = dataStore.createIndexStore();
 
     // Add indices
     final StringBuilder indexParam = new StringBuilder();
     for (int i = 0; i < indexOptions.size(); i++) {
-      String indexName = "test-index" + i;
+      final String indexName = "test-index" + i;
       if (indexStore.getIndex(indexName) == null) {
         indexOptions.get(i).setName(indexName);
         indexStore.addIndex(indexOptions.get(i).createIndex());
@@ -281,7 +282,7 @@ public class TestUtils {
       indexParam.append(indexName + ",");
     }
     // Create the command and execute.
-    final LocalToGeowaveCommand localIngester = new LocalToGeowaveCommand();
+    final LocalToGeoWaveCommand localIngester = new LocalToGeoWaveCommand();
     localIngester.setPluginFormats(ingestFormatOptions);
     localIngester.setParameters(ingestFilePath, "test-store", indexParam.toString());
     localIngester.setThreads(nthreads);
@@ -327,7 +328,7 @@ public class TestUtils {
 
     final StringBuilder indexParam = new StringBuilder();
     for (int i = 0; i < indexOptions.size(); i++) {
-      String indexName = "test-index" + i;
+      final String indexName = "test-index" + i;
       if (indexStore.getIndex(indexName) == null) {
         indexOptions.get(i).setName(indexName);
         indexStore.addIndex(indexOptions.get(i).createIndex());
@@ -340,7 +341,7 @@ public class TestUtils {
     configS3.execute(operationParams);
 
     // Create the command and execute.
-    final LocalToGeowaveCommand localIngester = new LocalToGeowaveCommand();
+    final LocalToGeoWaveCommand localIngester = new LocalToGeoWaveCommand();
     localIngester.setPluginFormats(ingestFormatOptions);
     localIngester.setParameters(ingestFilePath, "test-store", indexParam.toString());
     localIngester.setThreads(nthreads);
@@ -415,7 +416,8 @@ public class TestUtils {
         indexes,
         new VisibilityOptions(),
         sparkOptions,
-        ingestFilePath);
+        ingestFilePath,
+        new JCommander().getConsole());
 
     verifyStats(dataStore);
   }

--- a/test/src/main/java/org/locationtech/geowave/test/kafka/KafkaTestUtils.java
+++ b/test/src/main/java/org/locationtech/geowave/test/kafka/KafkaTestUtils.java
@@ -14,7 +14,7 @@ import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import org.locationtech.geowave.core.cli.operations.config.options.ConfigOptions;
 import org.locationtech.geowave.core.cli.parser.ManualOperationParams;
-import org.locationtech.geowave.core.ingest.operations.KafkaToGeowaveCommand;
+import org.locationtech.geowave.core.ingest.operations.KafkaToGeoWaveCommand;
 import org.locationtech.geowave.core.ingest.operations.LocalToKafkaCommand;
 import org.locationtech.geowave.core.ingest.operations.options.IngestFormatPluginOptions;
 import org.locationtech.geowave.core.store.cli.store.AddStoreCommand;
@@ -83,7 +83,7 @@ public class KafkaTestUtils {
     indexOption.selectPlugin((spatialTemporal ? "spatial_temporal" : "spatial"));
 
     // Execute Command
-    final KafkaToGeowaveCommand kafkaToGeowave = new KafkaToGeowaveCommand();
+    final KafkaToGeoWaveCommand kafkaToGeowave = new KafkaToGeoWaveCommand();
     final File configFile = File.createTempFile("test_stats", null);
     final ManualOperationParams params = new ManualOperationParams();
 

--- a/test/src/main/java/org/locationtech/geowave/test/mapreduce/MapReduceTestUtils.java
+++ b/test/src/main/java/org/locationtech/geowave/test/mapreduce/MapReduceTestUtils.java
@@ -19,7 +19,7 @@ import org.locationtech.geowave.adapter.vector.export.VectorMRExportCommand;
 import org.locationtech.geowave.adapter.vector.export.VectorMRExportOptions;
 import org.locationtech.geowave.core.cli.operations.config.options.ConfigOptions;
 import org.locationtech.geowave.core.cli.parser.ManualOperationParams;
-import org.locationtech.geowave.core.ingest.operations.LocalToMapReduceToGeowaveCommand;
+import org.locationtech.geowave.core.ingest.operations.LocalToMapReduceToGeoWaveCommand;
 import org.locationtech.geowave.core.ingest.operations.options.IngestFormatPluginOptions;
 import org.locationtech.geowave.core.store.cli.store.AddStoreCommand;
 import org.locationtech.geowave.core.store.cli.store.DataStorePluginOptions;
@@ -142,7 +142,7 @@ public class MapReduceTestUtils {
     configHdfs.setHdfsUrlParameter(env.getHdfs());
     configHdfs.execute(operationParams);
 
-    final LocalToMapReduceToGeowaveCommand mrGw = new LocalToMapReduceToGeowaveCommand();
+    final LocalToMapReduceToGeoWaveCommand mrGw = new LocalToMapReduceToGeoWaveCommand();
 
     final AddStoreCommand addStore = new AddStoreCommand();
     addStore.setParameters("test-store");

--- a/test/src/main/java/org/locationtech/geowave/test/services/grpc/GeoWaveGrpcTestClient.java
+++ b/test/src/main/java/org/locationtech/geowave/test/services/grpc/GeoWaveGrpcTestClient.java
@@ -74,7 +74,7 @@ import org.locationtech.geowave.service.grpc.protobuf.GeoServerRemoveWorkspaceCo
 import org.locationtech.geowave.service.grpc.protobuf.GeoServerSetLayerStyleCommandParametersProtos;
 import org.locationtech.geowave.service.grpc.protobuf.GeoWaveReturnTypesProtos.MapStringStringResponseProtos;
 import org.locationtech.geowave.service.grpc.protobuf.GeoWaveReturnTypesProtos.StringResponseProtos;
-import org.locationtech.geowave.service.grpc.protobuf.KafkaToGeowaveCommandParametersProtos;
+import org.locationtech.geowave.service.grpc.protobuf.KafkaToGeoWaveCommandParametersProtos;
 import org.locationtech.geowave.service.grpc.protobuf.KdeCommandParametersProtos;
 import org.locationtech.geowave.service.grpc.protobuf.KmeansSparkCommandParametersProtos;
 import org.locationtech.geowave.service.grpc.protobuf.ListCommandParametersProtos;
@@ -84,11 +84,11 @@ import org.locationtech.geowave.service.grpc.protobuf.ListIngestPluginsCommandPa
 import org.locationtech.geowave.service.grpc.protobuf.ListStatsCommandParametersProtos;
 import org.locationtech.geowave.service.grpc.protobuf.ListStorePluginsCommandParametersProtos;
 import org.locationtech.geowave.service.grpc.protobuf.ListTypesCommandParametersProtos;
-import org.locationtech.geowave.service.grpc.protobuf.LocalToGeowaveCommandParametersProtos;
+import org.locationtech.geowave.service.grpc.protobuf.LocalToGeoWaveCommandParametersProtos;
 import org.locationtech.geowave.service.grpc.protobuf.LocalToHdfsCommandParametersProtos;
 import org.locationtech.geowave.service.grpc.protobuf.LocalToKafkaCommandParametersProtos;
-import org.locationtech.geowave.service.grpc.protobuf.LocalToMapReduceToGeowaveCommandParametersProtos;
-import org.locationtech.geowave.service.grpc.protobuf.MapReduceToGeowaveCommandParametersProtos;
+import org.locationtech.geowave.service.grpc.protobuf.LocalToMapReduceToGeoWaveCommandParametersProtos;
+import org.locationtech.geowave.service.grpc.protobuf.MapReduceToGeoWaveCommandParametersProtos;
 import org.locationtech.geowave.service.grpc.protobuf.NearestNeighborCommandParametersProtos;
 import org.locationtech.geowave.service.grpc.protobuf.RecalculateStatsCommandParametersProtos;
 import org.locationtech.geowave.service.grpc.protobuf.RemoveIndexCommandParametersProtos;
@@ -97,7 +97,7 @@ import org.locationtech.geowave.service.grpc.protobuf.RemoveStoreCommandParamete
 import org.locationtech.geowave.service.grpc.protobuf.RemoveTypeCommandParametersProtos;
 import org.locationtech.geowave.service.grpc.protobuf.SetCommandParametersProtos;
 import org.locationtech.geowave.service.grpc.protobuf.SparkSqlCommandParametersProtos;
-import org.locationtech.geowave.service.grpc.protobuf.SparkToGeowaveCommandParametersProtos;
+import org.locationtech.geowave.service.grpc.protobuf.SparkToGeoWaveCommandParametersProtos;
 import org.locationtech.geowave.service.grpc.protobuf.SpatialJoinCommandParametersProtos;
 import org.locationtech.geowave.service.grpc.protobuf.SpatialQueryParametersProtos;
 import org.locationtech.geowave.service.grpc.protobuf.SpatialTemporalQueryParametersProtos;
@@ -810,10 +810,10 @@ public class GeoWaveGrpcTestClient {
 
     final ArrayList<String> extensions = new ArrayList<>();
 
-    final LocalToGeowaveCommandParametersProtos request =
-        LocalToGeowaveCommandParametersProtos.newBuilder().addAllParameters(
+    final LocalToGeoWaveCommandParametersProtos request =
+        LocalToGeoWaveCommandParametersProtos.newBuilder().addAllParameters(
             params).addAllExtensions(extensions).setFormats("gpx").setThreads(1).build();
-    coreIngestBlockingStub.localToGeowaveCommand(request);
+    coreIngestBlockingStub.localToGeoWaveCommand(request);
     return true;
   }
 
@@ -824,11 +824,11 @@ public class GeoWaveGrpcTestClient {
     params.add(GeoWaveGrpcTestUtils.indexName);
 
     final ArrayList<String> extensions = new ArrayList<>();
-    final MapReduceToGeowaveCommandParametersProtos request =
-        MapReduceToGeowaveCommandParametersProtos.newBuilder().addAllParameters(
+    final MapReduceToGeoWaveCommandParametersProtos request =
+        MapReduceToGeoWaveCommandParametersProtos.newBuilder().addAllParameters(
             params).addAllExtensions(extensions).setFormats("gpx").setJobTrackerHostPort(
                 GeoWaveGrpcTestUtils.getMapReduceTestEnv().getJobtracker()).build();
-    coreIngestBlockingStub.mapReduceToGeowaveCommand(request);
+    coreIngestBlockingStub.mapReduceToGeoWaveCommand(request);
     return true;
   }
 
@@ -851,12 +851,12 @@ public class GeoWaveGrpcTestClient {
 
     final ArrayList<String> extensions = new ArrayList<>();
 
-    final SparkToGeowaveCommandParametersProtos request =
-        SparkToGeowaveCommandParametersProtos.newBuilder().addAllParameters(
+    final SparkToGeoWaveCommandParametersProtos request =
+        SparkToGeoWaveCommandParametersProtos.newBuilder().addAllParameters(
             params).addAllExtensions(extensions).setFormats("gpx").setAppName(
                 "CoreGeoWaveSparkITs").setMaster("local[*]").setHost("localhost").setNumExecutors(
                     1).setNumCores(1).build();
-    coreIngestBlockingStub.sparkToGeowaveCommand(request);
+    coreIngestBlockingStub.sparkToGeoWaveCommand(request);
     return true;
   }
 
@@ -869,11 +869,11 @@ public class GeoWaveGrpcTestClient {
 
     final ArrayList<String> extensions = new ArrayList<>();
 
-    final LocalToMapReduceToGeowaveCommandParametersProtos request =
-        LocalToMapReduceToGeowaveCommandParametersProtos.newBuilder().addAllParameters(
+    final LocalToMapReduceToGeoWaveCommandParametersProtos request =
+        LocalToMapReduceToGeoWaveCommandParametersProtos.newBuilder().addAllParameters(
             params).addAllExtensions(extensions).setFormats("gpx").setJobTrackerHostPort(
                 GeoWaveGrpcTestUtils.getMapReduceTestEnv().getJobtracker()).build();
-    coreIngestBlockingStub.localToMapReduceToGeowaveCommand(request);
+    coreIngestBlockingStub.localToMapReduceToGeoWaveCommand(request);
     return true;
   }
 
@@ -884,14 +884,14 @@ public class GeoWaveGrpcTestClient {
 
     final ArrayList<String> extensions = new ArrayList<>();
 
-    final KafkaToGeowaveCommandParametersProtos request =
-        KafkaToGeowaveCommandParametersProtos.newBuilder().addAllParameters(
+    final KafkaToGeoWaveCommandParametersProtos request =
+        KafkaToGeoWaveCommandParametersProtos.newBuilder().addAllParameters(
             params).addAllExtensions(extensions).setFormats("gpx").setGroupId(
                 "testGroup").setZookeeperConnect(
                     GeoWaveGrpcTestUtils.getZookeeperTestEnv().getZookeeper()).setAutoOffsetReset(
                         "smallest").setFetchMessageMaxBytes("5000000").setConsumerTimeoutMs(
                             "5000").setReconnectOnTimeout(false).setBatchSize(10000).build();
-    coreIngestBlockingStub.kafkaToGeowaveCommand(request);
+    coreIngestBlockingStub.kafkaToGeoWaveCommand(request);
     return true;
   }
 


### PR DESCRIPTION
updated jcommander to v1.78

the major impact this had was no longer using a static instance of JCommander's `Console` which touched a lot of places.

While in "commands" I cleaned them and ensured that it didn't change the annotated parameters with "final" by adding setters (generally have adopted that as the best practice to avoid cleanup impacting functionality because JCommander uses reflection it will throw exceptions for inaccessible fields if they are final).

Also renamed the few places that I came across that still have "Geowave" when it should be "GeoWave" consistently across the project for class names.