### PR TITLE
Fix issues and add improvements to basic data type adapters

### DIFF
--- a/core/geotime/src/test/java/org/locationtech/geowave/core/geotime/adapter/annotation/SpatialTemporalAnnotationsTest.java
+++ b/core/geotime/src/test/java/org/locationtech/geowave/core/geotime/adapter/annotation/SpatialTemporalAnnotationsTest.java
@@ -100,7 +100,7 @@ public class SpatialTemporalAnnotationsTest {
       }
     }
 
-    final TestType builtEntry = adapter.buildObject(fields);
+    final TestType builtEntry = adapter.buildObject("id1", fields);
     assertEquals("id1", adapter.getFieldValue(builtEntry, "name"));
     assertTrue(
         GeometryUtils.GEOMETRY_FACTORY.createPoint(new Coordinate(10, 10)).equalsExact(

--- a/core/geotime/src/test/java/org/locationtech/geowave/core/geotime/store/query/filter/expression/CQLToGeoWaveFilterTest.java
+++ b/core/geotime/src/test/java/org/locationtech/geowave/core/geotime/store/query/filter/expression/CQLToGeoWaveFilterTest.java
@@ -656,7 +656,8 @@ public class CQLToGeoWaveFilterTest {
     final Index aIndex =
         AttributeDimensionalityTypeProvider.createIndexForDescriptor(
             adapter,
-            adapter.getFieldDescriptor("A"));
+            adapter.getFieldDescriptor("A"),
+            "aIndex");
     mapping = BaseDataStoreUtils.mapAdapterToIndex(adapter.asInternalAdapter((short) 0), aIndex);
     constraints =
         f.getConstraints(Double.class, null, adapter, mapping, aIndex, Sets.newHashSet("A"));
@@ -680,7 +681,8 @@ public class CQLToGeoWaveFilterTest {
     final Index bIndex =
         AttributeDimensionalityTypeProvider.createIndexForDescriptor(
             adapter,
-            adapter.getFieldDescriptor("B"));
+            adapter.getFieldDescriptor("B"),
+            "bIndex");
     mapping = BaseDataStoreUtils.mapAdapterToIndex(adapter.asInternalAdapter((short) 0), bIndex);
     constraints =
         f.getConstraints(Double.class, null, adapter, mapping, bIndex, Sets.newHashSet("B"));
@@ -699,7 +701,8 @@ public class CQLToGeoWaveFilterTest {
     final Index nameIndex =
         AttributeDimensionalityTypeProvider.createIndexForDescriptor(
             adapter,
-            adapter.getFieldDescriptor("name"));
+            adapter.getFieldDescriptor("name"),
+            "nameIndex");
     mapping = BaseDataStoreUtils.mapAdapterToIndex(adapter.asInternalAdapter((short) 0), nameIndex);
     FilterConstraints<String> textConstraints =
         f.getConstraints(String.class, null, adapter, mapping, nameIndex, Sets.newHashSet("name"));

--- a/core/geotime/src/test/java/org/locationtech/geowave/core/geotime/store/query/filter/expression/SpatialTemporalFilterExpressionTest.java
+++ b/core/geotime/src/test/java/org/locationtech/geowave/core/geotime/store/query/filter/expression/SpatialTemporalFilterExpressionTest.java
@@ -699,7 +699,7 @@ public class SpatialTemporalFilterExpressionTest {
     public TestTypeBasicDataAdapter() {}
 
     public TestTypeBasicDataAdapter(final String typeName) {
-      super(typeName, fields, "name");
+      super(typeName, fields, fields[2]);
     }
 
     @Override
@@ -716,7 +716,7 @@ public class SpatialTemporalFilterExpressionTest {
     }
 
     @Override
-    public TestType buildObject(Object[] fieldValues) {
+    public TestType buildObject(final Object dataId, Object[] fieldValues) {
       return new TestType(
           (Geometry) fieldValues[0],
           (Date) fieldValues[1],

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/adapter/SimpleAbstractDataAdapter.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/adapter/SimpleAbstractDataAdapter.java
@@ -21,17 +21,13 @@ abstract public class SimpleAbstractDataAdapter<T extends Persistable> implement
     DataTypeAdapter<T> {
   protected static final String SINGLETON_FIELD_NAME = "FIELD";
   protected FieldDescriptor<T> singletonFieldDescriptor;
-  private final FieldReader<Object> reader;
-  private final FieldWriter<Object> writer;
+  private FieldReader<Object> reader = null;
+  private FieldWriter<Object> writer = null;
 
   public SimpleAbstractDataAdapter() {
     super();
     singletonFieldDescriptor =
         new FieldDescriptorBuilder<>(getDataClass()).fieldName(SINGLETON_FIELD_NAME).build();
-    reader =
-        new PersistableReader(
-            PersistableFactory.getInstance().getClassIdMapping().get(getDataClass()));
-    writer = new PersistableWriter();
   }
 
   @Override
@@ -64,11 +60,19 @@ abstract public class SimpleAbstractDataAdapter<T extends Persistable> implement
 
   @Override
   public FieldWriter<Object> getWriter(final String fieldName) {
+    if (writer == null) {
+      writer = new PersistableWriter();
+    }
     return writer;
   }
 
   @Override
   public FieldReader<Object> getReader(final String fieldName) {
+    if (reader == null) {
+      reader =
+          new PersistableReader(
+              PersistableFactory.getInstance().getClassIdMapping().get(getDataClass()));
+    }
     return reader;
   }
 }

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/index/AttributeDimensionalityTypeProvider.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/index/AttributeDimensionalityTypeProvider.java
@@ -9,6 +9,7 @@
 package org.locationtech.geowave.core.store.index;
 
 import java.util.ServiceLoader;
+import javax.annotation.Nullable;
 import org.locationtech.geowave.core.store.adapter.FieldDescriptor;
 import org.locationtech.geowave.core.store.api.AttributeIndex;
 import org.locationtech.geowave.core.store.api.DataStore;
@@ -70,19 +71,24 @@ public class AttributeDimensionalityTypeProvider implements
               + options.getAttributeName()
               + "' could not be found in the type.");
     }
-    return createIndexForDescriptor(adapter, descriptor);
+    return createIndexForDescriptor(adapter, descriptor, options.getIndexName());
   }
 
   public static Index createIndexForDescriptor(
       final DataTypeAdapter<?> adapter,
-      final FieldDescriptor<?> descriptor) {
+      final FieldDescriptor<?> descriptor,
+      final @Nullable String indexName) {
     if (serviceLoader == null) {
       serviceLoader = ServiceLoader.load(AttributeIndexProviderSpi.class);
     }
     for (final AttributeIndexProviderSpi indexProvider : serviceLoader) {
       if (indexProvider.supportsDescriptor(descriptor)) {
         return indexProvider.buildIndex(
-            AttributeIndex.defaultAttributeIndexName(adapter.getTypeName(), descriptor.fieldName()),
+            indexName == null
+                ? AttributeIndex.defaultAttributeIndexName(
+                    adapter.getTypeName(),
+                    descriptor.fieldName())
+                : indexName,
             adapter,
             descriptor);
       }

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/index/AttributeIndexOptions.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/index/AttributeIndexOptions.java
@@ -28,11 +28,22 @@ public class AttributeIndexOptions implements DimensionalityTypeOptions {
       description = "The name of the attribute to index.")
   protected String attributeName;
 
+  @Parameter(names = {"--indexName"}, required = false, description = "The name of the index.")
+  protected String indexName;
+
   public AttributeIndexOptions() {}
 
   public AttributeIndexOptions(final String typeName, final String attributeName) {
+    this(typeName, attributeName, null);
+  }
+
+  public AttributeIndexOptions(
+      final String typeName,
+      final String attributeName,
+      final String indexName) {
     this.typeName = typeName;
     this.attributeName = attributeName;
+    this.indexName = indexName;
   }
 
   public void setTypeName(final String typeName) {
@@ -49,6 +60,14 @@ public class AttributeIndexOptions implements DimensionalityTypeOptions {
 
   public String getAttributeName() {
     return attributeName;
+  }
+
+  public void setIndexName(final String indexName) {
+    this.indexName = indexName;
+  }
+
+  public String getIndexName() {
+    return indexName;
   }
 
 }

--- a/core/store/src/test/java/org/locationtech/geowave/core/store/TestStorePersistableRegistry.java
+++ b/core/store/src/test/java/org/locationtech/geowave/core/store/TestStorePersistableRegistry.java
@@ -11,6 +11,7 @@ package org.locationtech.geowave.core.store;
 import org.locationtech.geowave.core.index.persist.InternalPersistableRegistry;
 import org.locationtech.geowave.core.index.persist.PersistableRegistrySpi;
 import org.locationtech.geowave.core.store.adapter.AbstractDataTypeAdapterTest.TestTypeBasicDataAdapter;
+import org.locationtech.geowave.core.store.adapter.AbstractDataTypeAdapterTest.TestTypeBasicDataAdapterSeparateDataID;
 import org.locationtech.geowave.core.store.adapter.MockComponents.MockAbstractDataAdapter;
 import org.locationtech.geowave.core.store.adapter.MockComponents.MockIndexStrategy;
 import org.locationtech.geowave.core.store.adapter.MockComponents.TestDimensionField;
@@ -31,6 +32,9 @@ public class TestStorePersistableRegistry implements
         new PersistableIdAndConstructor((short) 10203, TestIndexModel::new),
         new PersistableIdAndConstructor((short) 10204, ExampleNumericIndexStrategy::new),
         new PersistableIdAndConstructor((short) 10205, ExampleDimensionOne::new),
-        new PersistableIdAndConstructor((short) 10206, TestTypeBasicDataAdapter::new)};
+        new PersistableIdAndConstructor((short) 10206, TestTypeBasicDataAdapter::new),
+        new PersistableIdAndConstructor(
+            (short) 10207,
+            TestTypeBasicDataAdapterSeparateDataID::new)};
   }
 }

--- a/core/store/src/test/java/org/locationtech/geowave/core/store/adapter/AbstractDataTypeAdapterTest.java
+++ b/core/store/src/test/java/org/locationtech/geowave/core/store/adapter/AbstractDataTypeAdapterTest.java
@@ -44,6 +44,49 @@ public class AbstractDataTypeAdapterTest {
     assertEquals(2.5, (double) adapter.getFieldValue(testEntry, "doubleField"), 0.001);
     assertEquals(8, adapter.getFieldValue(testEntry, "intField"));
     assertTrue((boolean) adapter.getFieldValue(testEntry, "boolField"));
+
+    final TestType builtEntry = adapter.buildObject("id1", new Object[] {"id1", 2.5, 8, true});
+    assertEquals("id1", builtEntry.name);
+    assertEquals(2.5, builtEntry.doubleField, 0.001);
+    assertEquals((Integer) 8, builtEntry.intField);
+    assertTrue(builtEntry.boolField);
+  }
+
+  @Test
+  public void testBasicDataTypeAdapterSeparateDataId() {
+    AbstractDataTypeAdapter<TestType> adapter =
+        new TestTypeBasicDataAdapterSeparateDataID("myType");
+
+    assertEquals("myType", adapter.getTypeName());
+    assertEquals(TestType.class, adapter.getDataClass());
+    assertEquals(3, adapter.getFieldDescriptors().length);
+    assertEquals("name", adapter.getDataIDFieldDescriptor().fieldName());
+    assertEquals("doubleField", adapter.getFieldDescriptors()[0].fieldName());
+    assertEquals("intField", adapter.getFieldDescriptors()[1].fieldName());
+    assertEquals("boolField", adapter.getFieldDescriptors()[2].fieldName());
+
+    final byte[] adapterBytes = PersistenceUtils.toBinary(adapter);
+    adapter = (AbstractDataTypeAdapter) PersistenceUtils.fromBinary(adapterBytes);
+
+    assertEquals("myType", adapter.getTypeName());
+    assertEquals(TestType.class, adapter.getDataClass());
+    assertEquals(3, adapter.getFieldDescriptors().length);
+    assertEquals("name", adapter.getDataIDFieldDescriptor().fieldName());
+    assertEquals("doubleField", adapter.getFieldDescriptors()[0].fieldName());
+    assertEquals("intField", adapter.getFieldDescriptors()[1].fieldName());
+    assertEquals("boolField", adapter.getFieldDescriptors()[2].fieldName());
+
+    final TestType testEntry = new TestType("id1", 2.5, 8, true);
+    assertEquals("id1", adapter.getFieldValue(testEntry, "name"));
+    assertEquals(2.5, (double) adapter.getFieldValue(testEntry, "doubleField"), 0.001);
+    assertEquals(8, adapter.getFieldValue(testEntry, "intField"));
+    assertTrue((boolean) adapter.getFieldValue(testEntry, "boolField"));
+
+    final TestType builtEntry = adapter.buildObject("id1", new Object[] {2.5, 8, true});
+    assertEquals("id1", builtEntry.name);
+    assertEquals(2.5, builtEntry.doubleField, 0.001);
+    assertEquals((Integer) 8, builtEntry.intField);
+    assertTrue(builtEntry.boolField);
   }
 
   public static class TestType {
@@ -77,7 +120,7 @@ public class AbstractDataTypeAdapterTest {
     public TestTypeBasicDataAdapter() {}
 
     public TestTypeBasicDataAdapter(final String typeName) {
-      super(typeName, fields, "name");
+      super(typeName, fields, fields[0]);
     }
 
     @Override
@@ -96,12 +139,56 @@ public class AbstractDataTypeAdapterTest {
     }
 
     @Override
-    public TestType buildObject(Object[] fieldValues) {
+    public TestType buildObject(final Object dataId, Object[] fieldValues) {
       return new TestType(
           (String) fieldValues[0],
           (Double) fieldValues[1],
           (Integer) fieldValues[2],
           (Boolean) fieldValues[3]);
+    }
+
+  }
+
+  public static class TestTypeBasicDataAdapterSeparateDataID extends
+      AbstractDataTypeAdapter<TestType> {
+
+    static final FieldDescriptor<?> dataIDField =
+        new FieldDescriptorBuilder<>(String.class).fieldName("name").build();
+    static final FieldDescriptor<?>[] fields =
+        new FieldDescriptor<?>[] {
+            new FieldDescriptorBuilder<>(Double.class).fieldName("doubleField").build(),
+            new FieldDescriptorBuilder<>(Integer.class).fieldName("intField").indexHint(
+                new IndexDimensionHint("test")).build(),
+            new FieldDescriptorBuilder<>(Boolean.class).fieldName("boolField").build()};
+
+    public TestTypeBasicDataAdapterSeparateDataID() {}
+
+    public TestTypeBasicDataAdapterSeparateDataID(final String typeName) {
+      super(typeName, fields, dataIDField);
+    }
+
+    @Override
+    public Object getFieldValue(TestType entry, String fieldName) {
+      switch (fieldName) {
+        case "name":
+          return entry.name;
+        case "doubleField":
+          return entry.doubleField;
+        case "intField":
+          return entry.intField;
+        case "boolField":
+          return entry.boolField;
+      }
+      return null;
+    }
+
+    @Override
+    public TestType buildObject(final Object dataId, Object[] fieldValues) {
+      return new TestType(
+          (String) dataId,
+          (Double) fieldValues[0],
+          (Integer) fieldValues[1],
+          (Boolean) fieldValues[2]);
     }
 
   }

--- a/core/store/src/test/java/org/locationtech/geowave/core/store/adapter/BasicDataTypeAdapterTest.java
+++ b/core/store/src/test/java/org/locationtech/geowave/core/store/adapter/BasicDataTypeAdapterTest.java
@@ -695,7 +695,7 @@ public class BasicDataTypeAdapterTest {
     assertEquals(5.3, (double) adapter.getFieldValue(builtEntry, "extraField"), 0.001);
     assertNull(builtEntry.ignoredField);
   }
-  
+
   @Test
   public void testSingleFieldDataAdapterSeparateDataID() {
     BasicDataTypeAdapter<SingleFieldTestType> adapter =
@@ -717,7 +717,7 @@ public class BasicDataTypeAdapterTest {
     assertNull(adapter.getFieldDescriptor("name"));
     assertNotNull(adapter.getDataIDFieldDescriptor());
     assertTrue(String.class.isAssignableFrom(adapter.getDataIDFieldDescriptor().bindingClass()));
-    
+
     final SingleFieldTestType testEntry = new SingleFieldTestType("id1");
     assertEquals("id1", adapter.getFieldValue(testEntry, "name"));
 
@@ -832,20 +832,20 @@ public class BasicDataTypeAdapterTest {
       this.extraField = extraField;
     }
   }
-  
+
   public static class SingleFieldTestType {
     private String name;
-    
+
     protected SingleFieldTestType() {}
-    
+
     public SingleFieldTestType(final String name) {
       this.name = name;
     }
-    
+
     public void setName(final String name) {
       this.name = name;
     }
-    
+
     public String getName() {
       return name;
     }

--- a/core/store/src/test/java/org/locationtech/geowave/core/store/adapter/BasicDataTypeAdapterTest.java
+++ b/core/store/src/test/java/org/locationtech/geowave/core/store/adapter/BasicDataTypeAdapterTest.java
@@ -81,7 +81,7 @@ public class BasicDataTypeAdapterTest {
       }
     }
 
-    final TestType builtEntry = adapter.buildObject(fields);
+    final TestType builtEntry = adapter.buildObject("id1", fields);
     assertEquals("id1", adapter.getFieldValue(builtEntry, "name"));
     assertEquals(2.5, (double) adapter.getFieldValue(builtEntry, "doubleField"), 0.001);
     assertEquals(8, adapter.getFieldValue(builtEntry, "intField"));
@@ -160,7 +160,7 @@ public class BasicDataTypeAdapterTest {
       }
     }
 
-    final InheritedTestType builtEntry = adapter.buildObject(fields);
+    final InheritedTestType builtEntry = adapter.buildObject("id1", fields);
     assertEquals("id1", adapter.getFieldValue(builtEntry, "name"));
     assertEquals(2.5, (double) adapter.getFieldValue(builtEntry, "doubleField"), 0.001);
     assertEquals(8, adapter.getFieldValue(builtEntry, "intField"));
@@ -250,7 +250,7 @@ public class BasicDataTypeAdapterTest {
       }
     }
 
-    final AnnotatedTestType builtEntry = adapter.buildObject(fields);
+    final AnnotatedTestType builtEntry = adapter.buildObject("id1", fields);
     assertEquals("id1", adapter.getFieldValue(builtEntry, "alternateName"));
     assertEquals(2.5, (double) adapter.getFieldValue(builtEntry, "doubleField"), 0.001);
     assertEquals(8, adapter.getFieldValue(builtEntry, "intField"));
@@ -354,7 +354,7 @@ public class BasicDataTypeAdapterTest {
       }
     }
 
-    final InheritedAnnotatedTestType builtEntry = adapter.buildObject(fields);
+    final InheritedAnnotatedTestType builtEntry = adapter.buildObject("id1", fields);
     assertEquals("id1", adapter.getFieldValue(builtEntry, "alternateName"));
     assertEquals(2.5, (double) adapter.getFieldValue(builtEntry, "doubleField"), 0.001);
     assertEquals(8, adapter.getFieldValue(builtEntry, "intField"));
@@ -363,9 +363,371 @@ public class BasicDataTypeAdapterTest {
     assertNull(builtEntry.ignoredField);
   }
 
+  @Test
+  public void testObjectBasedDataAdapterSeparateDataID() {
+    BasicDataTypeAdapter<TestType> adapter =
+        BasicDataTypeAdapter.newAdapter("myType", TestType.class, "name", true);
+
+    assertEquals("myType", adapter.getTypeName());
+    assertEquals(TestType.class, adapter.getDataClass());
+    assertEquals(3, adapter.getFieldDescriptors().length);
+    assertNull(adapter.getFieldDescriptor("name"));
+    assertNotNull(adapter.getDataIDFieldDescriptor());
+    assertTrue(String.class.isAssignableFrom(adapter.getDataIDFieldDescriptor().bindingClass()));
+    assertNotNull(adapter.getFieldDescriptor("doubleField"));
+    assertTrue(
+        Double.class.isAssignableFrom(adapter.getFieldDescriptor("doubleField").bindingClass()));
+    assertNotNull(adapter.getFieldDescriptor("intField"));
+    assertTrue(
+        Integer.class.isAssignableFrom(adapter.getFieldDescriptor("intField").bindingClass()));
+    assertNotNull(adapter.getFieldDescriptor("boolField"));
+    assertTrue(
+        Boolean.class.isAssignableFrom(adapter.getFieldDescriptor("boolField").bindingClass()));
+
+    final byte[] adapterBytes = PersistenceUtils.toBinary(adapter);
+    adapter = (BasicDataTypeAdapter) PersistenceUtils.fromBinary(adapterBytes);
+
+    assertEquals("myType", adapter.getTypeName());
+    assertEquals(TestType.class, adapter.getDataClass());
+    assertEquals(3, adapter.getFieldDescriptors().length);
+    assertNull(adapter.getFieldDescriptor("name"));
+    assertNotNull(adapter.getDataIDFieldDescriptor());
+    assertTrue(String.class.isAssignableFrom(adapter.getDataIDFieldDescriptor().bindingClass()));
+    assertNotNull(adapter.getFieldDescriptor("doubleField"));
+    assertTrue(
+        Double.class.isAssignableFrom(adapter.getFieldDescriptor("doubleField").bindingClass()));
+    assertNotNull(adapter.getFieldDescriptor("intField"));
+    assertTrue(
+        Integer.class.isAssignableFrom(adapter.getFieldDescriptor("intField").bindingClass()));
+    assertNotNull(adapter.getFieldDescriptor("boolField"));
+    assertTrue(
+        Boolean.class.isAssignableFrom(adapter.getFieldDescriptor("boolField").bindingClass()));
+
+    final TestType testEntry = new TestType("id1", 2.5, 8, true);
+    assertEquals("id1", adapter.getFieldValue(testEntry, "name"));
+    assertEquals(2.5, (double) adapter.getFieldValue(testEntry, "doubleField"), 0.001);
+    assertEquals(8, adapter.getFieldValue(testEntry, "intField"));
+    assertTrue((boolean) adapter.getFieldValue(testEntry, "boolField"));
+
+    final Object[] fields = new Object[3];
+    for (int i = 0; i < fields.length; i++) {
+      switch (adapter.getFieldDescriptors()[i].fieldName()) {
+        case "doubleField":
+          fields[i] = 2.5;
+          break;
+        case "intField":
+          fields[i] = 8;
+          break;
+        case "boolField":
+          fields[i] = true;
+          break;
+      }
+    }
+
+    final TestType builtEntry = adapter.buildObject("id1", fields);
+    assertEquals("id1", adapter.getFieldValue(builtEntry, "name"));
+    assertEquals(2.5, (double) adapter.getFieldValue(builtEntry, "doubleField"), 0.001);
+    assertEquals(8, adapter.getFieldValue(builtEntry, "intField"));
+    assertTrue((boolean) adapter.getFieldValue(builtEntry, "boolField"));
+  }
+
+  @Test
+  public void testInheritedObjectBasedDataAdapterSeparateDataID() {
+    BasicDataTypeAdapter<InheritedTestType> adapter =
+        BasicDataTypeAdapter.newAdapter("myType", InheritedTestType.class, "name", true);
+
+    assertEquals("myType", adapter.getTypeName());
+    assertEquals(InheritedTestType.class, adapter.getDataClass());
+    assertEquals(4, adapter.getFieldDescriptors().length);
+    assertNull(adapter.getFieldDescriptor("name"));
+    assertNotNull(adapter.getDataIDFieldDescriptor());
+    assertTrue(String.class.isAssignableFrom(adapter.getDataIDFieldDescriptor().bindingClass()));
+    assertNotNull(adapter.getFieldDescriptor("doubleField"));
+    assertTrue(
+        Double.class.isAssignableFrom(adapter.getFieldDescriptor("doubleField").bindingClass()));
+    assertNotNull(adapter.getFieldDescriptor("intField"));
+    assertTrue(
+        Integer.class.isAssignableFrom(adapter.getFieldDescriptor("intField").bindingClass()));
+    assertNotNull(adapter.getFieldDescriptor("boolField"));
+    assertTrue(
+        Boolean.class.isAssignableFrom(adapter.getFieldDescriptor("boolField").bindingClass()));
+    assertNotNull(adapter.getFieldDescriptor("extraField"));
+    assertTrue(
+        String.class.isAssignableFrom(adapter.getFieldDescriptor("extraField").bindingClass()));
+
+    final byte[] adapterBytes = PersistenceUtils.toBinary(adapter);
+    adapter = (BasicDataTypeAdapter) PersistenceUtils.fromBinary(adapterBytes);
+
+    assertEquals("myType", adapter.getTypeName());
+    assertEquals(InheritedTestType.class, adapter.getDataClass());
+    assertEquals(4, adapter.getFieldDescriptors().length);
+    assertNull(adapter.getFieldDescriptor("name"));
+    assertNotNull(adapter.getDataIDFieldDescriptor());
+    assertTrue(String.class.isAssignableFrom(adapter.getDataIDFieldDescriptor().bindingClass()));
+    assertNotNull(adapter.getFieldDescriptor("doubleField"));
+    assertTrue(
+        Double.class.isAssignableFrom(adapter.getFieldDescriptor("doubleField").bindingClass()));
+    assertNotNull(adapter.getFieldDescriptor("intField"));
+    assertTrue(
+        Integer.class.isAssignableFrom(adapter.getFieldDescriptor("intField").bindingClass()));
+    assertNotNull(adapter.getFieldDescriptor("boolField"));
+    assertTrue(
+        Boolean.class.isAssignableFrom(adapter.getFieldDescriptor("boolField").bindingClass()));
+    assertNotNull(adapter.getFieldDescriptor("extraField"));
+    assertTrue(
+        String.class.isAssignableFrom(adapter.getFieldDescriptor("extraField").bindingClass()));
+
+    final InheritedTestType testEntry = new InheritedTestType("id1", 2.5, 8, true, "extra");
+    assertEquals("id1", adapter.getFieldValue(testEntry, "name"));
+    assertEquals(2.5, (double) adapter.getFieldValue(testEntry, "doubleField"), 0.001);
+    assertEquals(8, adapter.getFieldValue(testEntry, "intField"));
+    assertTrue((boolean) adapter.getFieldValue(testEntry, "boolField"));
+    assertEquals("extra", adapter.getFieldValue(testEntry, "extraField"));
+
+    final Object[] fields = new Object[4];
+    for (int i = 0; i < fields.length; i++) {
+      switch (adapter.getFieldDescriptors()[i].fieldName()) {
+        case "doubleField":
+          fields[i] = 2.5;
+          break;
+        case "intField":
+          fields[i] = 8;
+          break;
+        case "boolField":
+          fields[i] = true;
+          break;
+        case "extraField":
+          fields[i] = "extra";
+          break;
+      }
+    }
+
+    final InheritedTestType builtEntry = adapter.buildObject("id1", fields);
+    assertEquals("id1", adapter.getFieldValue(builtEntry, "name"));
+    assertEquals(2.5, (double) adapter.getFieldValue(builtEntry, "doubleField"), 0.001);
+    assertEquals(8, adapter.getFieldValue(builtEntry, "intField"));
+    assertTrue((boolean) adapter.getFieldValue(builtEntry, "boolField"));
+    assertEquals("extra", adapter.getFieldValue(builtEntry, "extraField"));
+  }
+
+  @Test
+  public void testAnnotatedObjectBasedDataAdapterSeparateDataID() {
+    BasicDataTypeAdapter<AnnotatedTestType> adapter =
+        BasicDataTypeAdapter.newAdapter("myType", AnnotatedTestType.class, "alternateName", true);
+
+    assertEquals("myType", adapter.getTypeName());
+    assertEquals(AnnotatedTestType.class, adapter.getDataClass());
+    assertEquals(3, adapter.getFieldDescriptors().length);
+    assertNull(adapter.getFieldDescriptor("alternateName"));
+    assertNotNull(adapter.getDataIDFieldDescriptor());
+    assertTrue(String.class.isAssignableFrom(adapter.getDataIDFieldDescriptor().bindingClass()));
+    assertTrue(
+        adapter.getDataIDFieldDescriptor().indexHints().contains(new IndexDimensionHint("a")));
+    assertNotNull(adapter.getFieldDescriptor("doubleField"));
+    assertTrue(
+        Double.class.isAssignableFrom(adapter.getFieldDescriptor("doubleField").bindingClass()));
+    assertNotNull(adapter.getFieldDescriptor("intField"));
+    assertTrue(
+        Integer.class.isAssignableFrom(adapter.getFieldDescriptor("intField").bindingClass()));
+    assertNotNull(adapter.getFieldDescriptor("boolField"));
+    assertTrue(
+        Boolean.class.isAssignableFrom(adapter.getFieldDescriptor("boolField").bindingClass()));
+    assertTrue(
+        adapter.getFieldDescriptor("boolField").indexHints().contains(new IndexDimensionHint("a")));
+    assertTrue(
+        adapter.getFieldDescriptor("boolField").indexHints().contains(new IndexDimensionHint("b")));
+    assertTrue(
+        adapter.getFieldDescriptor("boolField").indexHints().contains(new IndexDimensionHint("c")));
+
+    final byte[] adapterBytes = PersistenceUtils.toBinary(adapter);
+    adapter = (BasicDataTypeAdapter) PersistenceUtils.fromBinary(adapterBytes);
+
+    assertEquals("myType", adapter.getTypeName());
+    assertEquals(AnnotatedTestType.class, adapter.getDataClass());
+    assertEquals(3, adapter.getFieldDescriptors().length);
+    assertNull(adapter.getFieldDescriptor("alternateName"));
+    assertNotNull(adapter.getDataIDFieldDescriptor());
+    assertTrue(String.class.isAssignableFrom(adapter.getDataIDFieldDescriptor().bindingClass()));
+    assertTrue(
+        adapter.getDataIDFieldDescriptor().indexHints().contains(new IndexDimensionHint("a")));
+    assertNotNull(adapter.getFieldDescriptor("doubleField"));
+    assertTrue(
+        Double.class.isAssignableFrom(adapter.getFieldDescriptor("doubleField").bindingClass()));
+    assertNotNull(adapter.getFieldDescriptor("intField"));
+    assertTrue(
+        Integer.class.isAssignableFrom(adapter.getFieldDescriptor("intField").bindingClass()));
+    assertNotNull(adapter.getFieldDescriptor("boolField"));
+    assertTrue(
+        Boolean.class.isAssignableFrom(adapter.getFieldDescriptor("boolField").bindingClass()));
+    assertTrue(
+        adapter.getFieldDescriptor("boolField").indexHints().contains(new IndexDimensionHint("a")));
+    assertTrue(
+        adapter.getFieldDescriptor("boolField").indexHints().contains(new IndexDimensionHint("b")));
+    assertTrue(
+        adapter.getFieldDescriptor("boolField").indexHints().contains(new IndexDimensionHint("c")));
+
+    final AnnotatedTestType testEntry = new AnnotatedTestType("id1", 2.5, 8, true, "ignored");
+    assertEquals("id1", adapter.getFieldValue(testEntry, "alternateName"));
+    assertEquals(2.5, (double) adapter.getFieldValue(testEntry, "doubleField"), 0.001);
+    assertEquals(8, adapter.getFieldValue(testEntry, "intField"));
+    assertTrue((boolean) adapter.getFieldValue(testEntry, "boolField"));
+
+    final Object[] fields = new Object[3];
+    for (int i = 0; i < fields.length; i++) {
+      switch (adapter.getFieldDescriptors()[i].fieldName()) {
+        case "doubleField":
+          fields[i] = 2.5;
+          break;
+        case "intField":
+          fields[i] = 8;
+          break;
+        case "boolField":
+          fields[i] = true;
+          break;
+      }
+    }
+
+    final AnnotatedTestType builtEntry = adapter.buildObject("id1", fields);
+    assertEquals("id1", adapter.getFieldValue(builtEntry, "alternateName"));
+    assertEquals(2.5, (double) adapter.getFieldValue(builtEntry, "doubleField"), 0.001);
+    assertEquals(8, adapter.getFieldValue(builtEntry, "intField"));
+    assertTrue((boolean) adapter.getFieldValue(builtEntry, "boolField"));
+    assertNull(builtEntry.ignoredField);
+  }
+
+  @Test
+  public void testInheritedAnnotatedObjectBasedDataAdapterSeparateDataID() {
+    BasicDataTypeAdapter<InheritedAnnotatedTestType> adapter =
+        BasicDataTypeAdapter.newAdapter(
+            "myType",
+            InheritedAnnotatedTestType.class,
+            "alternateName",
+            true);
+
+    assertEquals("myType", adapter.getTypeName());
+    assertEquals(InheritedAnnotatedTestType.class, adapter.getDataClass());
+    assertEquals(4, adapter.getFieldDescriptors().length);
+    assertNull(adapter.getFieldDescriptor("alternateName"));
+    assertNotNull(adapter.getDataIDFieldDescriptor());
+    assertTrue(String.class.isAssignableFrom(adapter.getDataIDFieldDescriptor().bindingClass()));
+    assertTrue(
+        adapter.getDataIDFieldDescriptor().indexHints().contains(new IndexDimensionHint("a")));
+    assertNotNull(adapter.getFieldDescriptor("doubleField"));
+    assertTrue(
+        Double.class.isAssignableFrom(adapter.getFieldDescriptor("doubleField").bindingClass()));
+    assertNotNull(adapter.getFieldDescriptor("intField"));
+    assertTrue(
+        Integer.class.isAssignableFrom(adapter.getFieldDescriptor("intField").bindingClass()));
+    assertNotNull(adapter.getFieldDescriptor("boolField"));
+    assertTrue(
+        Boolean.class.isAssignableFrom(adapter.getFieldDescriptor("boolField").bindingClass()));
+    assertTrue(
+        adapter.getFieldDescriptor("boolField").indexHints().contains(new IndexDimensionHint("a")));
+    assertTrue(
+        adapter.getFieldDescriptor("boolField").indexHints().contains(new IndexDimensionHint("b")));
+    assertTrue(
+        adapter.getFieldDescriptor("boolField").indexHints().contains(new IndexDimensionHint("c")));
+    assertNotNull(adapter.getFieldDescriptor("extraField"));
+    assertTrue(
+        Double.class.isAssignableFrom(adapter.getFieldDescriptor("extraField").bindingClass()));
+
+    final byte[] adapterBytes = PersistenceUtils.toBinary(adapter);
+    adapter = (BasicDataTypeAdapter) PersistenceUtils.fromBinary(adapterBytes);
+
+    assertEquals("myType", adapter.getTypeName());
+    assertEquals(InheritedAnnotatedTestType.class, adapter.getDataClass());
+    assertEquals(4, adapter.getFieldDescriptors().length);
+    assertNull(adapter.getFieldDescriptor("alternateName"));
+    assertNotNull(adapter.getDataIDFieldDescriptor());
+    assertTrue(String.class.isAssignableFrom(adapter.getDataIDFieldDescriptor().bindingClass()));
+    assertTrue(
+        adapter.getDataIDFieldDescriptor().indexHints().contains(new IndexDimensionHint("a")));
+    assertNotNull(adapter.getFieldDescriptor("doubleField"));
+    assertTrue(
+        Double.class.isAssignableFrom(adapter.getFieldDescriptor("doubleField").bindingClass()));
+    assertNotNull(adapter.getFieldDescriptor("intField"));
+    assertTrue(
+        Integer.class.isAssignableFrom(adapter.getFieldDescriptor("intField").bindingClass()));
+    assertNotNull(adapter.getFieldDescriptor("boolField"));
+    assertTrue(
+        Boolean.class.isAssignableFrom(adapter.getFieldDescriptor("boolField").bindingClass()));
+    assertTrue(
+        adapter.getFieldDescriptor("boolField").indexHints().contains(new IndexDimensionHint("a")));
+    assertTrue(
+        adapter.getFieldDescriptor("boolField").indexHints().contains(new IndexDimensionHint("b")));
+    assertTrue(
+        adapter.getFieldDescriptor("boolField").indexHints().contains(new IndexDimensionHint("c")));
+    assertNotNull(adapter.getFieldDescriptor("extraField"));
+    assertTrue(
+        Double.class.isAssignableFrom(adapter.getFieldDescriptor("extraField").bindingClass()));
+
+    final InheritedAnnotatedTestType testEntry =
+        new InheritedAnnotatedTestType("id1", 2.5, 8, true, "ignored", 5.3);
+    assertEquals("id1", adapter.getFieldValue(testEntry, "alternateName"));
+    assertEquals(2.5, (double) adapter.getFieldValue(testEntry, "doubleField"), 0.001);
+    assertEquals(8, adapter.getFieldValue(testEntry, "intField"));
+    assertTrue((boolean) adapter.getFieldValue(testEntry, "boolField"));
+    assertEquals(5.3, (double) adapter.getFieldValue(testEntry, "extraField"), 0.001);
+
+    final Object[] fields = new Object[4];
+    for (int i = 0; i < fields.length; i++) {
+      switch (adapter.getFieldDescriptors()[i].fieldName()) {
+        case "doubleField":
+          fields[i] = 2.5;
+          break;
+        case "intField":
+          fields[i] = 8;
+          break;
+        case "boolField":
+          fields[i] = true;
+          break;
+        case "extraField":
+          fields[i] = 5.3;
+          break;
+      }
+    }
+
+    final InheritedAnnotatedTestType builtEntry = adapter.buildObject("id1", fields);
+    assertEquals("id1", adapter.getFieldValue(builtEntry, "alternateName"));
+    assertEquals(2.5, (double) adapter.getFieldValue(builtEntry, "doubleField"), 0.001);
+    assertEquals(8, adapter.getFieldValue(builtEntry, "intField"));
+    assertTrue((boolean) adapter.getFieldValue(builtEntry, "boolField"));
+    assertEquals(5.3, (double) adapter.getFieldValue(builtEntry, "extraField"), 0.001);
+    assertNull(builtEntry.ignoredField);
+  }
+  
+  @Test
+  public void testSingleFieldDataAdapterSeparateDataID() {
+    BasicDataTypeAdapter<SingleFieldTestType> adapter =
+        BasicDataTypeAdapter.newAdapter("myType", SingleFieldTestType.class, "name", true);
+
+    assertEquals("myType", adapter.getTypeName());
+    assertEquals(SingleFieldTestType.class, adapter.getDataClass());
+    assertEquals(0, adapter.getFieldDescriptors().length);
+    assertNull(adapter.getFieldDescriptor("name"));
+    assertNotNull(adapter.getDataIDFieldDescriptor());
+    assertTrue(String.class.isAssignableFrom(adapter.getDataIDFieldDescriptor().bindingClass()));
+
+    final byte[] adapterBytes = PersistenceUtils.toBinary(adapter);
+    adapter = (BasicDataTypeAdapter) PersistenceUtils.fromBinary(adapterBytes);
+
+    assertEquals("myType", adapter.getTypeName());
+    assertEquals(SingleFieldTestType.class, adapter.getDataClass());
+    assertEquals(0, adapter.getFieldDescriptors().length);
+    assertNull(adapter.getFieldDescriptor("name"));
+    assertNotNull(adapter.getDataIDFieldDescriptor());
+    assertTrue(String.class.isAssignableFrom(adapter.getDataIDFieldDescriptor().bindingClass()));
+    
+    final SingleFieldTestType testEntry = new SingleFieldTestType("id1");
+    assertEquals("id1", adapter.getFieldValue(testEntry, "name"));
+
+    final SingleFieldTestType builtEntry = adapter.buildObject("id1", new Object[0]);
+    assertEquals("id1", adapter.getFieldValue(builtEntry, "name"));
+  }
+
   public static class TestType {
     private String name;
-    public double doubleField;
+    private double doubleField;
     public int intField;
     public boolean boolField;
 
@@ -388,6 +750,14 @@ public class BasicDataTypeAdapterTest {
 
     public String getName() {
       return name;
+    }
+
+    public void setDoubleField(final double doubleField) {
+      this.doubleField = doubleField;
+    }
+
+    public double getDoubleField() {
+      return doubleField;
     }
   }
 
@@ -429,9 +799,9 @@ public class BasicDataTypeAdapterTest {
 
     public AnnotatedTestType(
         final String name,
-        final Double doubleField,
-        final Integer intField,
-        final Boolean boolField,
+        final double doubleField,
+        final int intField,
+        final boolean boolField,
         final String ignoredField) {
       this.name = name;
       this.doubleField = doubleField;
@@ -460,6 +830,24 @@ public class BasicDataTypeAdapterTest {
         final Double extraField) {
       super(name, doubleField, intField, boolField, ignoredField);
       this.extraField = extraField;
+    }
+  }
+  
+  public static class SingleFieldTestType {
+    private String name;
+    
+    protected SingleFieldTestType() {}
+    
+    public SingleFieldTestType(final String name) {
+      this.name = name;
+    }
+    
+    public void setName(final String name) {
+      this.name = name;
+    }
+    
+    public String getName() {
+      return name;
     }
   }
 }

--- a/core/store/src/test/java/org/locationtech/geowave/core/store/query/gwql/AbstractGWQLTest.java
+++ b/core/store/src/test/java/org/locationtech/geowave/core/store/query/gwql/AbstractGWQLTest.java
@@ -36,7 +36,7 @@ public abstract class AbstractGWQLTest {
     final DataStore dataStore = storeFamily.getDataStoreFactory().createStore(opts);
     final FieldDescriptor<?> descriptor = adapter.getFieldDescriptor(indexField);
     final Index index =
-        AttributeDimensionalityTypeProvider.createIndexForDescriptor(adapter, descriptor);
+        AttributeDimensionalityTypeProvider.createIndexForDescriptor(adapter, descriptor, null);
     dataStore.addType(adapter, index);
     return dataStore;
   }

--- a/examples/java-api/src/main/java/org/locationtech/geowave/examples/adapter/CustomAdapterExample.java
+++ b/examples/java-api/src/main/java/org/locationtech/geowave/examples/adapter/CustomAdapterExample.java
@@ -174,7 +174,7 @@ public class CustomAdapterExample {
     public POIBasicDataAdapter() {}
 
     public POIBasicDataAdapter(final String typeName) {
-      super(typeName, FIELDS, NAME_FIELD_NAME);
+      super(typeName, FIELDS, NAME_FIELD);
     }
 
     @Override
@@ -191,7 +191,7 @@ public class CustomAdapterExample {
     }
 
     @Override
-    public POI buildObject(final Object[] fieldValues) {
+    public POI buildObject(final Object dataId, final Object[] fieldValues) {
       return new POI((String) fieldValues[0], (Double) fieldValues[1], (Double) fieldValues[2]);
     }
 

--- a/test/src/test/java/org/locationtech/geowave/test/query/ExpressionQueryIT.java
+++ b/test/src/test/java/org/locationtech/geowave/test/query/ExpressionQueryIT.java
@@ -2700,7 +2700,7 @@ public class ExpressionQueryIT extends AbstractGeoWaveBasicVectorIT {
     final Index latitudeIndex =
         AttributeDimensionalityTypeProvider.createIndexFromOptions(
             ds,
-            new AttributeIndexOptions(TYPE_NAME, LATITUDE_FIELD));
+            new AttributeIndexOptions(TYPE_NAME, LATITUDE_FIELD, "latitudeIndex"));
 
     ds.addIndex(TYPE_NAME, latitudeIndex);
 


### PR DESCRIPTION
- Fix issues with the use of primitive types
- Allow the data ID field to be kept separate from the other fields so that they don't get serialized twice
- Allow the naming of attribute indices
- Allow no field descriptors to be supplied
- Update data ID serialization to use the field writer for the class instead of toString
- Fix stack overflow on SimpleAbstractDataAdapter