### PR TITLE
Suppress multiple binding warnings for installer

### DIFF
--- a/dev-resources/src/main/resources/assemblies/default-installer-plugin.xml
+++ b/dev-resources/src/main/resources/assemblies/default-installer-plugin.xml
@@ -59,6 +59,7 @@
 				<exclude>*:commons-digester</exclude>
 				<exclude>*:jcommander</exclude>
 				<exclude>*:log4j</exclude>
+				<exclude>*:log4j-slf4j*</exclude>
 				<exclude>*:zookeeper</exclude>
 				<exclude>*:metrics-core</exclude>
 				<exclude>joda-time:joda-time</exclude>


### PR DESCRIPTION
Testing the log4j updates in the installer revealed the need to exclude the new log4j version to suppress the multiple binding warnings when using the installed version of GeoWave.