### PR TITLE
Various Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ We work to maintain a N and N-1 tested and supported version pace for the follow
 
 | GeoServer | GeoTools | Accumulo | HBase | Hadoop | Java |
 |:---------:|:--------:|:--------:|:-----:|:------:|:----:|
-| 2.14.x | 20.x | [1.7.x,1.9.x] | [1.1.x,1.4.x] | 2.x | Java8 |
+| 2.19.x | 25.x | [1.9.x,2.0.x] | 2.4.x | 3.1.x | Java8 |
 
 * [Apache Maven](http://maven.apache.org/) 3.x or greater is required for building
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ We work to maintain a N and N-1 tested and supported version pace for the follow
 
 | GeoServer | GeoTools | Accumulo | HBase | Hadoop | Java |
 |:---------:|:--------:|:--------:|:-----:|:------:|:----:|
-| 2.19.x | 25.x | [1.9.x,2.0.x] | 2.4.x | 3.1.x | Java8 |
+| 2.19.x | 25.x | [1.9.x,2.0.x] | 2.4.x | [2.10.x,3.1.x] | Java8 |
 
 * [Apache Maven](http://maven.apache.org/) 3.x or greater is required for building
 

--- a/core/mapreduce/src/main/java/org/locationtech/geowave/mapreduce/operations/CopyCommand.java
+++ b/core/mapreduce/src/main/java/org/locationtech/geowave/mapreduce/operations/CopyCommand.java
@@ -27,7 +27,7 @@ import com.beust.jcommander.Parameters;
 import com.beust.jcommander.ParametersDelegate;
 
 @GeowaveOperation(name = "copymr", parentOperation = StoreSection.class)
-@Parameters(commandDescription = "Copy all data from one data store to another using MapReduce")
+@Parameters(commandDescription = "Copy all data from one data store to another existing data store using MapReduce")
 public class CopyCommand extends DefaultOperation implements Command {
   @Parameter(description = "<input store name> <output store name>")
   private List<String> parameters = new ArrayList<>();

--- a/core/mapreduce/src/main/java/org/locationtech/geowave/mapreduce/operations/CopyCommand.java
+++ b/core/mapreduce/src/main/java/org/locationtech/geowave/mapreduce/operations/CopyCommand.java
@@ -27,7 +27,8 @@ import com.beust.jcommander.Parameters;
 import com.beust.jcommander.ParametersDelegate;
 
 @GeowaveOperation(name = "copymr", parentOperation = StoreSection.class)
-@Parameters(commandDescription = "Copy all data from one data store to another existing data store using MapReduce")
+@Parameters(
+    commandDescription = "Copy all data from one data store to another existing data store using MapReduce")
 public class CopyCommand extends DefaultOperation implements Command {
   @Parameter(description = "<input store name> <output store name>")
   private List<String> parameters = new ArrayList<>();

--- a/core/store/src/main/java/org/locationtech/geowave/core/store/cli/store/CopyStoreCommand.java
+++ b/core/store/src/main/java/org/locationtech/geowave/core/store/cli/store/CopyStoreCommand.java
@@ -21,7 +21,7 @@ import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
 
 @GeowaveOperation(name = "copy", parentOperation = StoreSection.class)
-@Parameters(commandDescription = "Copy all data from one data store to another")
+@Parameters(commandDescription = "Copy all data from one data store to another existing data store")
 public class CopyStoreCommand extends DefaultOperation implements Command {
   @Parameter(description = "<input store name> <output store name>")
   private List<String> parameters = new ArrayList<>();

--- a/dev-resources/src/main/resources/assemblies/default-installer-plugin.xml
+++ b/dev-resources/src/main/resources/assemblies/default-installer-plugin.xml
@@ -59,6 +59,7 @@
 				<exclude>*:commons-digester</exclude>
 				<exclude>*:jcommander</exclude>
 				<exclude>*:log4j</exclude>
+				<exclude>*:log4j-slf4j*</exclude>
 				<exclude>*:zookeeper</exclude>
 				<exclude>*:metrics-core</exclude>
 				<exclude>joda-time:joda-time</exclude>

--- a/docs/content/commands/manpages/store/geowave-copy.txt
+++ b/docs/content/commands/manpages/store/geowave-copy.txt
@@ -14,7 +14,7 @@ geowave-store-copy - Copy a data store
 [[store-copy-description]]
 ==== DESCRIPTION
 
-This command copies all of the data from one data store to another.
+This command copies all of the data from one data store to another existing data store.
 
 [[store-copy-examples]]
 ==== EXAMPLES

--- a/docs/content/commands/manpages/store/geowave-copymr.txt
+++ b/docs/content/commands/manpages/store/geowave-copymr.txt
@@ -14,7 +14,7 @@ geowave-store-copymr - Copy a data store using MapReduce
 [[store-copymr-description]]
 ==== DESCRIPTION
 
-This command copies all of the data from one data store to another using MapReduce.
+This command copies all of the data from one data store to another existing data store using MapReduce.
 
 [[store-copymr-options]]
 ==== OPTIONS


### PR DESCRIPTION
Testing the log4j updates in the installer revealed the need to exclude the new log4j version to suppress the multiple binding warnings when using the installed version of GeoWave.